### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/xygine/CMakeLists.txt
+++ b/xygine/CMakeLists.txt
@@ -44,7 +44,7 @@ else()
 endif()
 
 if(UNIX)
-  find_package(X11 REQUIRED)
+  #find_package(X11 REQUIRED) # On modern versions of Mac (at least as of 10.8) X11 is not installed automatically - and probably not needed?
 endif()
 
 SET(BOX2D_MIN_VERSION "2.3.2")


### PR DESCRIPTION
Commented out X11 dependency in the main CMakeLists.txt file.

X11 can be installed on modern Mac's but it's on optional O/S component.

We probably do not need it for xygine?
I assume it was included in here due to the original CMakeLists.txt template?