### PR TITLE
Add constructor for CollisionRectangleShape which takes sf::FloatRect

### DIFF
--- a/xygine/include/xygine/physics/CollisionRectangleShape.hpp
+++ b/xygine/include/xygine/physics/CollisionRectangleShape.hpp
@@ -56,15 +56,15 @@ namespace xy
             */
             CollisionRectangleShape(const sf::Vector2f& size, const sf::Vector2f& position = sf::Vector2f());
 
-			/*!
-			\brief Creates a box from a size.
-
-			When attached to a rigidbody the position is relative to its parent,
-			else it is in world coordinates
-
-			\param sf::FloatRect an sf::FloatRect representing the size and position of the
-			*/
-			CollisionRectangleShape(const sf::FloatRect& size);
+            /*!
+            \brief Creates a box from a size.
+            
+            When attached to a rigidbody the position is relative to its parent,
+            else it is in world coordinates
+            
+            \param sf::FloatRect an sf::FloatRect representing the size and position of the
+            */
+            CollisionRectangleShape(const sf::FloatRect& size);
 			~CollisionRectangleShape() = default;
             CollisionRectangleShape(const CollisionRectangleShape&);
             const CollisionRectangleShape& operator = (const CollisionRectangleShape&) = delete;

--- a/xygine/include/xygine/physics/CollisionRectangleShape.hpp
+++ b/xygine/include/xygine/physics/CollisionRectangleShape.hpp
@@ -55,6 +55,16 @@ namespace xy
             \param position Position of the box relative to the parent body
             */
             CollisionRectangleShape(const sf::Vector2f& size, const sf::Vector2f& position = sf::Vector2f());
+
+			/*!
+			\brief Creates a box from a size.
+
+			When attached to a rigidbody the position is relative to its parent,
+			else it is in world coordinates
+
+			\param sf::FloatRect an sf::FloatRect representing the size and position of the
+			*/
+			CollisionRectangleShape(const sf::FloatRect& size);
             ~CollisionRectangleShape() = default;
             CollisionRectangleShape(const CollisionRectangleShape&);
             const CollisionRectangleShape& operator = (const CollisionRectangleShape&) = delete;

--- a/xygine/include/xygine/physics/CollisionRectangleShape.hpp
+++ b/xygine/include/xygine/physics/CollisionRectangleShape.hpp
@@ -65,7 +65,7 @@ namespace xy
 			\param sf::FloatRect an sf::FloatRect representing the size and position of the
 			*/
 			CollisionRectangleShape(const sf::FloatRect& size);
-            ~CollisionRectangleShape() = default;
+			~CollisionRectangleShape() = default;
             CollisionRectangleShape(const CollisionRectangleShape&);
             const CollisionRectangleShape& operator = (const CollisionRectangleShape&) = delete;
 

--- a/xygine/src/physics/PhysicsCollisionRectangleShape.cpp
+++ b/xygine/src/physics/PhysicsCollisionRectangleShape.cpp
@@ -40,6 +40,12 @@ CollisionRectangleShape::CollisionRectangleShape(const sf::Vector2f& size, const
     setShape(m_rectangleShape);
 }
 
+xy::Physics::CollisionRectangleShape::CollisionRectangleShape(const sf::FloatRect & size)
+{
+	setRect(size);
+	setShape(m_rectangleShape);
+}
+
 CollisionRectangleShape::CollisionRectangleShape(const CollisionRectangleShape& other)
     : CollisionShape(other)
 {


### PR DESCRIPTION
It has a setRect(sf::FloatRect) so this makes sense, e.g.

`xy::Physics::CollisionRectangleShape shape({ 0.f, 0.f, 40.f, 100.f });`
