### PR TITLE
Added Anti-aliasing control to the App Class

### DIFF
--- a/xygine/include/xygine/App.hpp
+++ b/xygine/include/xygine/App.hpp
@@ -76,12 +76,14 @@ namespace xy
         {
             sf::Int32 WindowStyle;
             sf::VideoMode VideoMode;
+            sf::ContextSettings ContextSettings;
             bool VSync;
             std::vector<sf::VideoMode> AvailableVideoModes;
 
             VideoSettings()
                 : WindowStyle(sf::Style::Close /*sf::Style::Fullscreen*/),
                 VideoMode(1024, 768),
+                ContextSettings(),
                 VSync(true){}
 
             bool operator == (const VideoSettings& vs)
@@ -89,6 +91,7 @@ namespace xy
                 if (&vs == this) return true;
                 return
                     (vs.VideoMode == this->VideoMode
+                    && vs.ContextSettings.antialiasingLevel == this->ContextSettings.antialiasingLevel
                     && vs.VSync == this->VSync
                     && vs.WindowStyle == this->WindowStyle);
             }
@@ -126,7 +129,7 @@ namespace xy
         (or other 3D features) a context with OpenGL version 3.2 or 
         higher is needed, as well as a depth buffer.
         */
-        App(sf::ContextSettings = sf::ContextSettings());
+        App();
         virtual ~App() = default;
         App(const App&) = delete;
         const App& operator = (const App&) = delete;
@@ -351,6 +354,7 @@ namespace xy
             int version;
 
             sf::VideoMode videoMode;
+            sf::ContextSettings contextSettings;
             sf::Int32 windowStyle;
             AudioSettings audioSettings;
             GameSettings gameSettings;

--- a/xygine/src/Console.cpp
+++ b/xygine/src/Console.cpp
@@ -45,6 +45,7 @@ namespace
     bool fullScreen = false;
 
     std::vector<sf::VideoMode> modes;
+    int currentAALevel = 0;
     int currentResolution = 0;
     char resolutionNames[300];
     
@@ -193,6 +194,9 @@ void Console::draw(App* app)
                         break;
                     }
                 }
+
+                //and correct AA level
+                currentAALevel = app->getVideoSettings().ContextSettings.antialiasingLevel;
             }
             nim::EndMenu();
         }
@@ -232,10 +236,19 @@ void Console::draw(App* app)
     //draw options window if visible
     if (!showVideoOptions) return;
 
-    nim::SetNextWindowSize({ 300.f, 100.f });
+    nim::SetNextWindowSize({ 305.f, 200.f });
     nim::Begin("Video Options", &showVideoOptions, ImGuiWindowFlags_ShowBorders);
 
     nim::Combo("Resolution", &currentResolution, resolutionNames);
+    nim::InputInt("Anti-aliasing", &currentAALevel);
+    if (nim::IsItemHovered())
+    {
+        nim::BeginTooltip();
+        nim::PushTextWrapPos(150.f);
+        nim::TextUnformatted("Anti-aliasing is only applicable when not using a post-process");
+        nim::PopTextWrapPos();
+        nim::EndTooltip();
+    }
 
     nim::Checkbox("Full Screen", &fullScreen);
     if (nim::Button("Apply", { 50.f, 20.f }))
@@ -244,7 +257,11 @@ void Console::draw(App* app)
         xy::App::VideoSettings settings;
         settings.WindowStyle = (fullScreen) ? sf::Style::Fullscreen : sf::Style::Close;
         settings.VideoMode = modes[currentResolution];
+        settings.ContextSettings.antialiasingLevel = currentAALevel;
         app->applyVideoSettings(settings);
+        
+        //update in case selected AA level was too high
+        currentAALevel = app->getVideoSettings().ContextSettings.antialiasingLevel;
     }
     nim::End();
 }


### PR DESCRIPTION
Specifically to the VideoSettings struct, which now also has an sf::ContextSettings member, so you can modify that when using the applyVideoSettings function. I also added the setting to the console  menu.

Worth noting the anti-aliasing won't be applied if using a post-process, as sf::Rendertexture does not (yet?) support it