### PR TITLE
restricted the AA menu to realistic values

### DIFF
--- a/xygine/src/App.cpp
+++ b/xygine/src/App.cpp
@@ -224,7 +224,7 @@ void App::applyVideoSettings(const VideoSettings& settings)
     auto newAA = m_renderWindow.getSettings().antialiasingLevel;
     if (oldAA != newAA)
     {
-        Logger::log("Requested Anti-aliasing level too high, using level: " + std::to_string(newAA), Logger::Type::Warning, Logger::Output::All);
+        Logger::log("Requested Anti-aliasing level not available, using level: " + std::to_string(newAA), Logger::Type::Warning, Logger::Output::All);
     }
 
     m_renderWindow.setVerticalSyncEnabled(settings.VSync);

--- a/xygine/src/Console.cpp
+++ b/xygine/src/Console.cpp
@@ -240,7 +240,7 @@ void Console::draw(App* app)
     nim::Begin("Video Options", &showVideoOptions, ImGuiWindowFlags_ShowBorders);
 
     nim::Combo("Resolution", &currentResolution, resolutionNames);
-    nim::InputInt("Anti-aliasing", &currentAALevel);
+    nim::SliderInt("Anti-aliasing", &currentAALevel, 0, 32);
     if (nim::IsItemHovered())
     {
         nim::BeginTooltip();


### PR DESCRIPTION
also improved accuracy of warning by minimum 87%