### PR TITLE
Use shields.io for badge and relabel. Reduce osx builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,13 +48,4 @@ matrix:
       compiler: clang
 
     - os: osx
-      osx_image: xcode6.4
-
-    - os: osx
-      osx_image: xcode7.3
-
-    - os: osx
-      osx_image: xcode8.3
-
-    - os: osx
       osx_image: xcode9


### PR DESCRIPTION
It was taking donkeys to build all the osx images, and it was probably overkill anyway, so I've reduced it to just use latest xcode.

I've also updated the badge in the readme to use shields.io and relabelled to "*nix" (feel free to change this)