### PR TITLE
Fixed issues with Demo on Apple

### DIFF
--- a/Demo/CMakeLists.txt
+++ b/Demo/CMakeLists.txt
@@ -33,7 +33,9 @@ find_package(TMXLITE REQUIRED)
 
 # X11 is required on unices
 if(UNIX)
+ if(!APPLE)
   find_package(X11 REQUIRED)
+ endif()
 endif()
 
 # Additional include directories

--- a/Demo/CMakeLists.txt
+++ b/Demo/CMakeLists.txt
@@ -16,6 +16,11 @@ SET(CMAKE_BUILD_TYPE        Debug CACHE STRING  "Choose the type of build (Debug
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Apple doesn't like static constexpr if c++17 isn't enabled
+if (APPLE)
+ set(CMAKE_CXX_STANDARD 17)
+endif()
+
 # enable some warnings in debug builds with gcc/clang
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -Wall -Wextra -Wreorder")

--- a/cmake template/CMakeLists.txt
+++ b/cmake template/CMakeLists.txt
@@ -16,6 +16,11 @@ SET(CMAKE_BUILD_TYPE        Debug CACHE STRING  "Choose the type of build (Debug
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Apple doesn't like static constexpr if c++17 isn't enabled
+if (APPLE)
+ set(CMAKE_CXX_STANDARD 17)
+endif()
+
 # enable some warnings in debug builds with gcc/clang
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -Wall -Wextra -Wreorder")
@@ -32,7 +37,9 @@ find_package(XYGINEXT REQUIRED)
 
 # X11 is required on unices
 if(UNIX)
+ if(!APPLE)
   find_package(X11 REQUIRED)
+ endif()
 endif()
 
 # Additional include directories
@@ -48,6 +55,11 @@ endif()
 # Project source files
 add_subdirectory(include)
 add_subdirectory(src)
+
+# Add XY_DEBUG on Debug builds
+if (CMAKE_BUILD_TYPE MATCHES Debug) 
+  add_definitions(-DXY_DEBUG)
+endif()
 
 # Create the actual executable (PROJECT_SRC variable is set inside previous steps)
 add_executable(${PROJECT_NAME} ${PROJECT_SRC})


### PR DESCRIPTION
X11 isn't required on Apple, and any variables declared static constexpr are undefined if I don't enable c++17 (mileage with other compilers may vary...)

Using AppleClang 9.0.0 and macOS 10.12