### PR TITLE
Enable building the demo with travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@
 language: c++
 sudo: true
 
-# Remove this if/when xyginext merged into master
-branches:
- only:
-  - xyginext
-
 addons:
  apt:
    packages:
@@ -32,12 +27,18 @@ before_script:
 
  - git clone https://github.com/sfml/sfml && cd sfml
  - git checkout tags/2.4.2
- - cmake . && sudo make install && cd ..
+ - cmake . && sudo cmake --build . --target install && cd ..
+
+# Also install TmxLite, required for Demo
+ - git clone https://github.com/fallahn/tmxlite
+ - cd tmxlite/tmxlite
+ - cmake . && sudo cmake --build . --target install && cd ../../
 
 script:
- - mkdir build && cd build
- - cmake ../xyginext
- - make
+ - cd xyginext && mkdir build && cd build
+ - cmake ../ && sudo cmake --build . --target install
+ - cd ../../Demo && mkdir build && cd build
+ - cmake ../ && cmake --build .
 
 matrix:
  include:

--- a/Demo/CMakeLists.txt
+++ b/Demo/CMakeLists.txt
@@ -16,11 +16,6 @@ SET(CMAKE_BUILD_TYPE        Debug CACHE STRING  "Choose the type of build (Debug
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Apple doesn't like static constexpr if c++17 isn't enabled
-if (APPLE)
- set(CMAKE_CXX_STANDARD 17)
-endif()
-
 # enable some warnings in debug builds with gcc/clang
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -Wall -Wextra -Wreorder")

--- a/Demo/CMakeLists.txt
+++ b/Demo/CMakeLists.txt
@@ -16,6 +16,11 @@ SET(CMAKE_BUILD_TYPE        Debug CACHE STRING  "Choose the type of build (Debug
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Apple doesn't like static constexpr if c++17 isn't enabled
+if (APPLE)
+ set(CMAKE_CXX_STANDARD 17)
+endif()
+
 # enable some warnings in debug builds with gcc/clang
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -Wall -Wextra -Wreorder")

--- a/Demo/src/ScoreTag.cpp
+++ b/Demo/src/ScoreTag.cpp
@@ -31,6 +31,8 @@ source distribution.
 #include <xyginext/ecs/components/Transform.hpp>
 #include <xyginext/ecs/Scene.hpp>
 
+const float ScoreTag::MaxLife = 2.f;
+
 namespace
 {
     const float speed = -120.f;

--- a/Demo/src/ScoreTag.hpp
+++ b/Demo/src/ScoreTag.hpp
@@ -32,7 +32,7 @@ source distribution.
 
 struct ScoreTag final
 {
-    static constexpr float MaxLife = 2.f;
+    static const float MaxLife;
     float lifetime = MaxLife;
     sf::Color colour = { 155, 255, 55 };
 };


### PR DESCRIPTION
This configures travis to build the demo project.

Compiles with g++ and later Xcode versions

Currently failing with clang because tmxlite needs a slight tweak, and on some older Xcode versions which don't support c++17 - would you rather remove the older Apple builds or remove the c++17 code from the demo?