### PR TITLE
Add include files to project source

### DIFF
--- a/xyginext/CMakeLists.txt
+++ b/xyginext/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.1)
 
 # Rename this variable to change the project name
 SET(PROJECT_NAME xyginext)
+project(${PROJECT_NAME})
 
 # Set the path to our find modules
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules/")
@@ -51,6 +52,7 @@ endif()
 
 # Project source files
 add_subdirectory(src)
+add_subdirectory(include/xyginext)
 
 # platform specific for file dialogue
 if(APPLE)
@@ -106,6 +108,5 @@ install(TARGETS ${PROJECT_NAME} EXPORT xyginext-targets
   ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin)
 
- # Configuration for packaging
- include(CPack)
-
+# Configuration for packaging
+include(CPack)

--- a/xyginext/include/xyginext/CMakeLists.txt
+++ b/xyginext/include/xyginext/CMakeLists.txt
@@ -1,0 +1,65 @@
+#source files used by xyginext library
+set(PROJECT_SRC  ${PROJECT_SRC}
+  ${CMAKE_CURRENT_SOURCE_DIR}/audio/AudioSourceImpl.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/audio/Mixer.hpp
+
+  ${CMAKE_CURRENT_SOURCE_DIR}/core/App.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/core/ConfigFile.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/core/Console.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/core/ConsoleClient.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/core/FileSystem.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/core/MessageBus.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/core/State.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/core/StateStack.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/core/SysTime.hpp
+
+  ${CMAKE_CURRENT_SOURCE_DIR}/detail/Operators.hpp
+
+  ${CMAKE_CURRENT_SOURCE_DIR}/ecs/Component.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ecs/Director.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ecs/Entity.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ecs/Scene.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ecs/System.hpp
+
+  ${CMAKE_CURRENT_SOURCE_DIR}/ecs/components/AudioEmitter.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ecs/components/Camera.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ecs/components/Drawable.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ecs/components/NetInterpolation.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ecs/components/ParticleEmitter.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ecs/components/QuadTreeItem.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ecs/components/Sprite.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ecs/components/Text.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ecs/components/Transform.hpp
+
+  ${CMAKE_CURRENT_SOURCE_DIR}/ecs/systems/AudioSystem.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ecs/systems/CallbackSystem.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ecs/systems/CameraSystem.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ecs/systems/CommandSystem.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ecs/systems/InterpolationSystem.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ecs/systems/ParticleSystem.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ecs/systems/QuadTree.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ecs/systems/RenderSystem.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ecs/systems/SpriteAnimator.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ecs/systems/SpriteSystem.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ecs/systems/TextRenderer.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ecs/systems/UISystem.hpp
+
+  ${CMAKE_CURRENT_SOURCE_DIR}/graphics/SpriteSheet.hpp
+
+  ${CMAKE_CURRENT_SOURCE_DIR}/graphics/postprocess/Antique.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/graphics/postprocess/Bloom.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/graphics/postprocess/Blur.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/graphics/postprocess/ChromeAb.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/graphics/postprocess/OldSchool.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/graphics/postprocess/PostProcess.hpp
+
+  ${CMAKE_CURRENT_SOURCE_DIR}/gui/Gui.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/gui/GuiClient.hpp
+
+  ${CMAKE_CURRENT_SOURCE_DIR}/network/NetClient.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/network/NetData.hpp
+
+  ${CMAKE_CURRENT_SOURCE_DIR}/resources/Resource.hpp
+  
+  ${CMAKE_CURRENT_SOURCE_DIR}/util/Random.hpp
+  PARENT_SCOPE)

--- a/xyginext/src/CMakeLists.txt
+++ b/xyginext/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 #source files used by xyginext library
-set(PROJECT_SRC 
+set(PROJECT_SRC ${PROJECT_SRC}
   ${CMAKE_CURRENT_SOURCE_DIR}/audio/AudioSourceImpl.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/audio/Mixer.cpp
 


### PR DESCRIPTION
Minor change to CMake to add the xyginext source files to the project, doesn't really have any impact on building, just means the project files generated by CMake are more complete, and you can browse the include files within the project

This also sets the project name, which I'm not sure how I missed before... 