### PR TITLE
VideoSettings equality operator needs to compare framerate limit

### DIFF
--- a/xyginext/include/xyginext/core/App.hpp
+++ b/xyginext/include/xyginext/core/App.hpp
@@ -109,7 +109,8 @@ namespace xy
                     (vs.VideoMode == this->VideoMode
                     && vs.ContextSettings.antialiasingLevel == this->ContextSettings.antialiasingLevel
                     && vs.VSync == this->VSync
-                    && vs.WindowStyle == this->WindowStyle);
+                    && vs.WindowStyle == this->WindowStyle
+                    && vs.FrameLimit == this->FrameLimit);
             }
         };
 


### PR DESCRIPTION
Was testing #72, and noticed that it isn't working because the == operator in VideoSettings doesn't compare the FrameLimit variable, meaning changes to that variable wouldn't be updated. This should fix that