### PR TITLE
Implemented gui style save/load

### DIFF
--- a/Demo/src/Game.cpp
+++ b/Demo/src/Game.cpp
@@ -38,9 +38,12 @@ source distribution.
 
 #include <SFML/Window/Event.hpp>
 
+#include <xyginext/gui/Gui.hpp>
+
 namespace
 {
     SharedStateData sharedData;
+    const std::string guiCfgPath = "guistyle.cfg";
     //sf::Cursor cursor;
 }
 
@@ -58,6 +61,17 @@ Game::Game()
   
     setWindowTitle("xygine - Castle Clamber (F1 for Options)");
     Locale::load("assets/localisation/chichewa.xyl");
+    
+    // Check for saved gui style
+    xy::Nim::Style style;
+    if (!style.loadFromFile(guiCfgPath))
+    {
+        xy::Logger::log("Gui style not found");
+    }
+    else
+    {
+        xy::Nim::setStyle(style);
+    }
 }
 
 //private
@@ -70,6 +84,14 @@ void Game::handleEvent(const sf::Event& evt)
         {
             default: break;
             case sf::Keyboard::Escape:
+                
+                // Save the gui style
+                auto style = xy::Nim::getStyle();
+                if (!style.saveToFile(guiCfgPath))
+                {
+                    xy::Logger::log("Failed to save gui style");
+                }
+                
                 xy::App::quit();
                 break;
         }

--- a/xyginext/include/xyginext/core/ConfigFile.hpp
+++ b/xyginext/include/xyginext/core/ConfigFile.hpp
@@ -93,6 +93,8 @@ namespace xy
         void setValue(float v);
         void setValue(bool v);
         void setValue(sf::Vector2f v);
+        void setValue(sf::Vector2i v);
+        void setValue(sf::Vector2u v);
         void setValue(sf::Vector3f v);
         void setValue(sf::FloatRect);
         void setValue(sf::Color);

--- a/xyginext/include/xyginext/core/ConfigFile.inl
+++ b/xyginext/include/xyginext/core/ConfigFile.inl
@@ -69,6 +69,33 @@ inline sf::Vector2f ConfigProperty::getValue<sf::Vector2f>() const
 }
 
 template <>
+inline sf::Vector2i ConfigProperty::getValue<sf::Vector2i>() const
+{
+    auto values = valueAsArray();
+    //sf::Vector2f retval; //loop allows for values to be the wrong size
+    //for (auto i = 0u; i < values.size() && i < 2; ++i)
+    //{
+    //    retval[i] = values[i];
+    //}
+    
+    return { static_cast<sf::Int32>(values[0]), static_cast<sf::Int32>(values[1]) };
+}
+
+template <>
+inline sf::Vector2u ConfigProperty::getValue<sf::Vector2u>() const
+{
+    auto values = valueAsArray();
+    //sf::Vector2f retval; //loop allows for values to be the wrong size
+    //for (auto i = 0u; i < values.size() && i < 2; ++i)
+    //{
+    //    retval[i] = values[i];
+    //}
+    
+    return { static_cast<sf::Uint32>(values[0]), static_cast<sf::Uint32>(values[1]) };
+}
+
+
+template <>
 inline sf::Vector3f ConfigProperty::getValue<sf::Vector3f>() const
 {
     auto values = valueAsArray();

--- a/xyginext/include/xyginext/gui/Gui.hpp
+++ b/xyginext/include/xyginext/gui/Gui.hpp
@@ -30,7 +30,10 @@ source distribution.
 
 #include "xyginext/Config.hpp"
 
+#include <SFML/Graphics/Color.hpp>
+
 #include <string>
+#include <array>
 
 namespace xy
 {
@@ -42,6 +45,93 @@ namespace xy
     */
     namespace Nim
     {
+        /*!
+         \see ImGui::ImGuiStyle
+         */
+        struct Style
+        {
+            // Enumeration for colours
+            enum class Colour
+            {
+                Text,
+                TextDisabled,
+                WindowBg,              // Background of normal windows
+                ChildBg,               // Background of child windows
+                PopupBg,               // Background of popups, menus, tooltips windows
+                Border,
+                BorderShadow,
+                FrameBg,               // Background of checkbox, radio button, plot, slider, text input
+                FrameBgHovered,
+                FrameBgActive,
+                TitleBg,
+                TitleBgActive,
+                TitleBgCollapsed,
+                MenuBarBg,
+                ScrollbarBg,
+                ScrollbarGrab,
+                ScrollbarGrabHovered,
+                ScrollbarGrabActive,
+                CheckMark,
+                SliderGrab,
+                SliderGrabActive,
+                Button,
+                ButtonHovered,
+                ButtonActive,
+                Header,
+                HeaderHovered,
+                HeaderActive,
+                Separator,
+                SeparatorHovered,
+                SeparatorActive,
+                ResizeGrip,
+                ResizeGripHovered,
+                ResizeGripActive,
+                PlotLines,
+                PlotLinesHovered,
+                PlotHistogram,
+                PlotHistogramHovered,
+                TextSelectedBg,
+                ModalWindowDarkening,  // darken entire screen when a modal window is active
+                DragDropTarget,
+                Count
+            };
+            
+            float           Alpha = 1.f;                      // Global alpha applies to everything in Nim
+            sf::Vector2i    WindowPadding = {8,8};              // Padding within a window
+            float           WindowRounding = 7.f;             // Radius of window corners rounding. Set to 0.0f to have rectangular windows
+            float           WindowBorderSize = 0.f;           // Thickness of border around windows. Generally set to 0.0f or 1.0f. (Other values are not well tested and more CPU/GPU costly)
+            sf::Vector2u    WindowMinSize = {32,32};              // Minimum window size
+            sf::Vector2f    WindowTitleAlign = {0.f,0.5f};           // Alignment for title bar text. Defaults to (0.0f,0.5f) for left-aligned,vertically centered.
+            float           ChildRounding = 0.f;              // Radius of child window corners rounding. Set to 0.0f to have rectangular windows.
+            float           ChildBorderSize = 1.f;            // Thickness of border around child windows. Generally set to 0.0f or 1.0f. (Other values are not well tested and more CPU/GPU costly)
+            float           PopupRounding = 0.f;              // Radius of popup window corners rounding.
+            float           PopupBorderSize = 1.f;            // Thickness of border around popup windows. Generally set to 0.0f or 1.0f. (Other values are not well tested and more CPU/GPU costly)
+            sf::Vector2i    FramePadding = {4,3};               // Padding within a framed rectangle (used by most widgets)
+            float           FrameRounding = 0.f;              // Radius of frame corners rounding. Set to 0.0f to have rectangular frame (used by most widgets).
+            float           FrameBorderSize = 1.f;            // Thickness of border around frames. Generally set to 0.0f or 1.0f. (Other values are not well tested and more CPU/GPU costly)
+            sf::Vector2i    ItemSpacing = {8,4} ;                // Horizontal and vertical spacing between widgets/lines
+            sf::Vector2i    ItemInnerSpacing = {4,4};           // Horizontal and vertical spacing between within elements of a composed widget (e.g. a slider and its label)
+            sf::Vector2i    TouchExtraPadding {0,0};          // Expand reactive bounding box for touch-based system where touch position is not accurate enough. Unfortunately we don't sort widgets so priority on overlap will always be given to the first widget. So don't grow this too much!
+            float           IndentSpacing = 21.f;              // Horizontal indentation when e.g. entering a tree node. Generally == (FontSize + FramePadding.x*2).
+            float           ColumnsMinSpacing = 6.f;          // Minimum horizontal spacing between two columns
+            float           ScrollbarSize = 16.f;              // Width of the vertical scrollbar, Height of the horizontal scrollbar
+            float           ScrollbarRounding = 9.f;          // Radius of grab corners for scrollbar
+            float           GrabMinSize = 10.f;                // Minimum width/height of a grab box for slider/scrollbar.
+            float           GrabRounding = 0.f;               // Radius of grabs corners rounding. Set to 0.0f to have rectangular slider grabs.
+            sf::Vector2f    ButtonTextAlign = {0.5f,0.5f};            // Alignment of button text when button is larger than text. Defaults to (0.5f,0.5f) for horizontally+vertically centered.
+            sf::Vector2i    DisplayWindowPadding = {22,22};       // Window positions are clamped to be visible within the display area by at least this amount. Only covers regular windows.
+            sf::Vector2i    DisplaySafeAreaPadding = {4,4};     // If you cannot see the edge of your screen (e.g. on a TV) increase the safe area padding. Covers popups/tooltips as well regular windows.
+            bool            AntiAliasedLines = true;           // Enable anti-aliasing on lines/borders. Disable if you are really tight on CPU/GPU.
+            bool            AntiAliasedFill = true;            // Enable anti-aliasing on filled shapes (rounded rectangles, circles, etc.)
+            float           CurveTessellationTol = 1.25f;       // Tessellation tolerance when using PathBezierCurveTo() without a specific number of segments. Decrease for highly tessellated curves (higher quality, more polygons), increase to reduce quality.
+            
+            std::array<sf::Color, static_cast<size_t>(Colour::Count)>         colours;
+            
+            XY_EXPORT_API   bool loadFromFile(const std::string& path);
+            XY_EXPORT_API   bool saveToFile(const std::string& path);
+            
+        };
+        
         /*!
         \see ImGui::Begin()
         */
@@ -97,6 +187,16 @@ namespace xy
          \see ImGui::GetIo().WantCaptureKeyboard
          */
         XY_EXPORT_API bool wantsKeyboard();
+        
+        /*!
+         \brief Get the current style
+         */
+        XY_EXPORT_API const Style& getStyle();
+        
+        /*!
+         \brief Set the current style
+         */
+        XY_EXPORT_API void setStyle(const Style& style);
     }
 }
 

--- a/xyginext/src/core/ConfigFile.cpp
+++ b/xyginext/src/core/ConfigFile.cpp
@@ -70,6 +70,16 @@ void ConfigProperty::setValue(sf::Vector2f v)
     m_value = std::to_string(v.x) + "," + std::to_string(v.y);
 }
 
+void ConfigProperty::setValue(sf::Vector2i v)
+{
+    m_value = std::to_string(v.x) + "," + std::to_string(v.y);
+}
+
+void ConfigProperty::setValue(sf::Vector2u v)
+{
+    m_value = std::to_string(v.x) + "," + std::to_string(v.y);
+}
+
 void ConfigProperty::setValue(sf::Vector3f v)
 {
     m_value = std::to_string(v.x) + "," + std::to_string(v.y) + "," + std::to_string(v.z);

--- a/xyginext/src/imgui/Gui.cpp
+++ b/xyginext/src/imgui/Gui.cpp
@@ -26,10 +26,19 @@ source distribution.
 *********************************************************************/
 
 #include "xyginext/gui/Gui.hpp"
+#include "xyginext/core/ConfigFile.hpp"
 
 #include "imgui.h"
 
+// Saves the hassle of mapping strings to all style vars
+#define GET_VARIABLE_NAME(Variable) (#Variable)
+
 using namespace xy;
+
+namespace
+{
+    static Nim::Style currentStyle;
+}
 
 void Nim::begin(const std::string& title, bool* b)
 {
@@ -86,5 +95,167 @@ bool Nim::wantsKeyboard()
     return ImGui::GetIO().WantCaptureKeyboard;
 }
 
+const Nim::Style& Nim::getStyle()
+{
+    auto style = ImGui::GetStyle();
+    auto& s = currentStyle;
+    s.Alpha = style.Alpha;
+    s.AntiAliasedFill = style.AntiAliasedFill;
+    s.AntiAliasedLines = style.AntiAliasedLines;
+    s.ButtonTextAlign = style.ButtonTextAlign;
+    s.ChildBorderSize = style.ChildBorderSize;
+    s.ChildRounding = style.ChildRounding;
+    s.ColumnsMinSpacing = style.ColumnsMinSpacing;
+    s.CurveTessellationTol = style.CurveTessellationTol;
+    s.DisplaySafeAreaPadding = style.DisplaySafeAreaPadding;
+    s.DisplayWindowPadding = style.DisplayWindowPadding;
+    s.FrameBorderSize = style.FrameBorderSize;
+    s.FramePadding = style.FramePadding;
+    s.FrameRounding = style.FrameRounding;
+    s.GrabMinSize = style.GrabMinSize;
+    s.GrabRounding = style.GrabRounding;
+    s.IndentSpacing = style.IndentSpacing;
+    s.ItemInnerSpacing = style.ItemInnerSpacing;
+    s.ItemSpacing = style.ItemSpacing;
+    s.PopupBorderSize = style.PopupBorderSize;
+    s.PopupRounding = style.PopupRounding;
+    s.ScrollbarRounding = style.ScrollbarRounding;
+    s.ScrollbarSize = style.ScrollbarSize;
+    s.TouchExtraPadding = style.TouchExtraPadding;
+    s.WindowBorderSize = style.WindowBorderSize;
+    s.WindowMinSize = style.WindowMinSize;
+    s.WindowPadding = style.WindowPadding;
+    s.WindowRounding = style.WindowRounding;
+    s.WindowTitleAlign = style.WindowTitleAlign;
+    for (auto i=0u; i < s.colours.size(); i++)
+        s.colours[i] = style.Colors[i];
+    return currentStyle;
+}
+
+void Nim::setStyle(const Nim::Style& style)
+{
+    // copy vars to imgui style
+    currentStyle = style;
+    auto& s = ImGui::GetStyle();
+    s.Alpha = style.Alpha;
+    s.AntiAliasedFill = style.AntiAliasedFill;
+    s.AntiAliasedLines = style.AntiAliasedLines;
+    s.ButtonTextAlign = style.ButtonTextAlign;
+    s.ChildBorderSize = style.ChildBorderSize;
+    s.ChildRounding = style.ChildRounding;
+    s.ColumnsMinSpacing = style.ColumnsMinSpacing;
+    s.CurveTessellationTol = style.CurveTessellationTol;
+    s.DisplaySafeAreaPadding = style.DisplaySafeAreaPadding;
+    s.DisplayWindowPadding = style.DisplayWindowPadding;
+    s.FrameBorderSize = style.FrameBorderSize;
+    s.FramePadding = style.FramePadding;
+    s.FrameRounding = style.FrameRounding;
+    s.GrabMinSize = style.GrabMinSize;
+    s.GrabRounding = style.GrabRounding;
+    s.IndentSpacing = style.IndentSpacing;
+    s.ItemInnerSpacing = style.ItemInnerSpacing;
+    s.ItemSpacing = style.ItemSpacing;
+    s.PopupBorderSize = style.PopupBorderSize;
+    s.PopupRounding = style.PopupRounding;
+    s.ScrollbarRounding = style.ScrollbarRounding;
+    s.ScrollbarSize = style.ScrollbarSize;
+    s.TouchExtraPadding = style.TouchExtraPadding;
+    s.WindowBorderSize = style.WindowBorderSize;
+    s.WindowMinSize = style.WindowMinSize;
+    s.WindowPadding = style.WindowPadding;
+    s.WindowRounding = style.WindowRounding;
+    s.WindowTitleAlign = style.WindowTitleAlign;
+    for (auto i=0u; i < style.colours.size(); i++)
+        s.Colors[i] = style.colours[i];
+}
+
+bool Nim::Style::saveToFile(const std::string& path)
+{
+    xy::ConfigFile styleFile;
+    
+    styleFile.addProperty(GET_VARIABLE_NAME(Alpha)).setValue(Alpha);
+    styleFile.addProperty(GET_VARIABLE_NAME(AntiAliasedFill)).setValue(AntiAliasedFill);
+    styleFile.addProperty(GET_VARIABLE_NAME(AntiAliasedLines)).setValue(AntiAliasedLines);
+    styleFile.addProperty(GET_VARIABLE_NAME(ButtonTextAlign)).setValue(ButtonTextAlign);
+    styleFile.addProperty(GET_VARIABLE_NAME(ChildBorderSize)).setValue(ChildBorderSize);
+    styleFile.addProperty(GET_VARIABLE_NAME(ChildRounding)).setValue(ChildRounding);
+    styleFile.addProperty(GET_VARIABLE_NAME(ColumnsMinSpacing)).setValue(ColumnsMinSpacing);
+    styleFile.addProperty(GET_VARIABLE_NAME(CurveTessellationTol)).setValue(CurveTessellationTol);
+    styleFile.addProperty(GET_VARIABLE_NAME(DisplaySafeAreaPadding)).setValue(DisplaySafeAreaPadding);
+    styleFile.addProperty(GET_VARIABLE_NAME(DisplayWindowPadding)).setValue(DisplayWindowPadding);
+    styleFile.addProperty(GET_VARIABLE_NAME(FrameBorderSize)).setValue(FrameBorderSize);
+    styleFile.addProperty(GET_VARIABLE_NAME(FramePadding)).setValue(FramePadding);
+    styleFile.addProperty(GET_VARIABLE_NAME(FrameRounding)).setValue(FrameRounding);
+    styleFile.addProperty(GET_VARIABLE_NAME(GrabMinSize)).setValue(GrabMinSize);
+    styleFile.addProperty(GET_VARIABLE_NAME(GrabRounding)).setValue(GrabRounding);
+    styleFile.addProperty(GET_VARIABLE_NAME(IndentSpacing)).setValue(IndentSpacing);
+    styleFile.addProperty(GET_VARIABLE_NAME(ItemInnerSpacing)).setValue(ItemInnerSpacing);
+    styleFile.addProperty(GET_VARIABLE_NAME(ItemSpacing)).setValue(ItemSpacing);
+    styleFile.addProperty(GET_VARIABLE_NAME(PopupBorderSize)).setValue(PopupBorderSize);
+    styleFile.addProperty(GET_VARIABLE_NAME(PopupRounding)).setValue(PopupRounding);
+    styleFile.addProperty(GET_VARIABLE_NAME(ScrollbarRounding)).setValue(ScrollbarRounding);
+    styleFile.addProperty(GET_VARIABLE_NAME(ScrollbarSize)).setValue(ScrollbarSize);
+    styleFile.addProperty(GET_VARIABLE_NAME(TouchExtraPadding)).setValue(TouchExtraPadding);
+    styleFile.addProperty(GET_VARIABLE_NAME(WindowBorderSize)).setValue(WindowBorderSize);
+    styleFile.addProperty(GET_VARIABLE_NAME(WindowMinSize)).setValue(WindowMinSize);
+    styleFile.addProperty(GET_VARIABLE_NAME(WindowPadding)).setValue(WindowPadding);
+    styleFile.addProperty(GET_VARIABLE_NAME(WindowRounding)).setValue(WindowRounding);
+    styleFile.addProperty(GET_VARIABLE_NAME(WindowTitleAlign)).setValue(WindowTitleAlign);
+    
+    auto colourObj = styleFile.addObject("Colours");
+    for (auto i=0u; i<colours.size(); i++)
+    {
+        colourObj->addProperty(std::to_string(i)).setValue(colours[i]);
+    }
+    
+    return styleFile.save(path);
+}
+
+bool Nim::Style::loadFromFile(const std::string& path)
+{
+    xy::ConfigFile styleFile;
+    if (!styleFile.loadFromFile(path))
+        return false;
+    
+    // I'm not going to check the property is found, bc I'm a loose cannon
+    // Also kind of wish I'd written a helper function before doing this...
+    Alpha = styleFile.findProperty(GET_VARIABLE_NAME(Alpha))->getValue<decltype(Alpha)>();
+    AntiAliasedFill = styleFile.findProperty(GET_VARIABLE_NAME(AntiAliasedFill))->getValue<decltype(AntiAliasedFill)>();
+    AntiAliasedLines = styleFile.findProperty(GET_VARIABLE_NAME(AntiAliasedLines))->getValue<decltype(AntiAliasedLines)>();
+    ButtonTextAlign = styleFile.findProperty(GET_VARIABLE_NAME(ButtonTextAlign))->getValue<decltype(ButtonTextAlign)>();
+    ChildBorderSize = styleFile.findProperty(GET_VARIABLE_NAME(ChildBorderSize))->getValue<decltype(ChildBorderSize)>();
+    ChildRounding = styleFile.findProperty(GET_VARIABLE_NAME(ChildRounding))->getValue<decltype(ChildRounding)>();
+    ColumnsMinSpacing = styleFile.findProperty(GET_VARIABLE_NAME(ColumnsMinSpacing))->getValue<decltype(ColumnsMinSpacing)>();
+    CurveTessellationTol = styleFile.findProperty(GET_VARIABLE_NAME(CurveTessellationTol))->getValue<decltype(CurveTessellationTol)>();
+    DisplaySafeAreaPadding = styleFile.findProperty(GET_VARIABLE_NAME(DisplaySafeAreaPadding))->getValue<decltype(DisplaySafeAreaPadding)>();
+    DisplayWindowPadding = styleFile.findProperty(GET_VARIABLE_NAME(DisplayWindowPadding))->getValue<decltype(DisplayWindowPadding)>();
+    FrameBorderSize = styleFile.findProperty(GET_VARIABLE_NAME(FrameBorderSize))->getValue<decltype(FrameBorderSize)>();
+    FramePadding = styleFile.findProperty(GET_VARIABLE_NAME(FramePadding))->getValue<decltype(FramePadding)>();
+    FrameRounding = styleFile.findProperty(GET_VARIABLE_NAME(FrameRounding))->getValue<decltype(FrameRounding)>();
+    GrabMinSize = styleFile.findProperty(GET_VARIABLE_NAME(GrabMinSize))->getValue<decltype(GrabMinSize)>();
+    GrabRounding = styleFile.findProperty(GET_VARIABLE_NAME(GrabRounding))->getValue<decltype(GrabRounding)>();
+    IndentSpacing = styleFile.findProperty(GET_VARIABLE_NAME(IndentSpacing))->getValue<decltype(IndentSpacing)>();
+    ItemInnerSpacing = styleFile.findProperty(GET_VARIABLE_NAME(ItemInnerSpacing))->getValue<decltype(ItemInnerSpacing)>();
+    ItemSpacing = styleFile.findProperty(GET_VARIABLE_NAME(ItemSpacing))->getValue<decltype(ItemSpacing)>();
+    PopupBorderSize = styleFile.findProperty(GET_VARIABLE_NAME(PopupBorderSize))->getValue<decltype(PopupBorderSize)>();
+    PopupRounding = styleFile.findProperty(GET_VARIABLE_NAME(PopupRounding))->getValue<decltype(currentStyle.PopupRounding)>();
+    ScrollbarRounding = styleFile.findProperty(GET_VARIABLE_NAME(ScrollbarRounding))->getValue<decltype(ScrollbarRounding)>();
+    ScrollbarSize = styleFile.findProperty(GET_VARIABLE_NAME(ScrollbarSize))->getValue<decltype(ScrollbarSize)>();
+    TouchExtraPadding = styleFile.findProperty(GET_VARIABLE_NAME(TouchExtraPadding))->getValue<decltype(TouchExtraPadding)>();
+    WindowBorderSize = styleFile.findProperty(GET_VARIABLE_NAME(WindowBorderSize))->getValue<decltype(WindowBorderSize)>();
+    WindowMinSize = styleFile.findProperty(GET_VARIABLE_NAME(WindowMinSize))->getValue<decltype(WindowMinSize)>();
+    WindowPadding = styleFile.findProperty(GET_VARIABLE_NAME(WindowPadding))->getValue<decltype(WindowPadding)>();
+    WindowRounding = styleFile.findProperty(GET_VARIABLE_NAME(WindowRounding))->getValue<decltype(WindowRounding)>();
+    WindowTitleAlign = styleFile.findProperty(GET_VARIABLE_NAME(WindowTitleAlign))->getValue<decltype(WindowTitleAlign)>();
+    
+    auto colourObj = styleFile.findObjectWithName("Colours");
+    for (auto i=0u; i<colours.size(); i++)
+    {
+        // Need a better method for this...
+        colours[i] = colourObj->findProperty(std::to_string(i))->getValue<sf::Color>();
+    }
+    
+    return true;
+}
 
 //I miss you like hell.


### PR DESCRIPTION
This implements saving/loading of the imgui style, addressing #60 

Copied the parameters from the imgui style struct, and using the xygine config file format.

To test, run the demo and quit (by pressing escape) to save the initial config file. Then modify some value in the config file and run the demo again to see the change.

I've tried to avoid having to use friendly strings for all the var names, which means the colours in particular are a little unclear (the config file just has the array index as the key, rather than the colour var name). I could address this either by explicitly saving each colour instead of looping over the array, or just mapping every style var to a friendly string.