### PR TITLE
Fix a bunch of warnings

### DIFF
--- a/Demo/src/BonusSystem.cpp
+++ b/Demo/src/BonusSystem.cpp
@@ -46,10 +46,10 @@ source distribution.
 
 namespace
 {
-    std::array<float, 5u> spawnTimes = { 11.f, 14.f, 13.f, 17.f, 14.f };
+    std::array<float, 5u> spawnTimes = {{ 11.f, 14.f, 13.f, 17.f, 14.f }};
 }
 
-std::array<Bonus::Value, 5u> Bonus::valueMap  = {B,O,N,U,S}; //this should be const but g++ complains
+std::array<Bonus::Value, 5u> Bonus::valueMap  = {{B,O,N,U,S}}; //this should be const but g++ complains
 
 BonusSystem::BonusSystem(xy::MessageBus& mb, xy::NetHost& host)
     : xy::System(mb, typeid(BonusSystem)),

--- a/Demo/src/CrateSystem.cpp
+++ b/Demo/src/CrateSystem.cpp
@@ -187,7 +187,7 @@ void CrateSystem::groundCollision(xy::Entity entity)
 
         if (hitboxes[i].getType() == CollisionType::Crate)
         {
-            for (auto j = 0; j < collisionCount; ++j)
+            for (auto j = 0u; j < collisionCount; ++j)
             {
                 switch (manifolds[j].otherType)
                 {
@@ -249,7 +249,7 @@ void CrateSystem::groundCollision(xy::Entity entity)
             auto collisions = collisionCount;
 
             //remove any contacts which shouldn't stop it from falling
-            for (auto j = 0; j < collisionCount; ++j)
+            for (auto j = 0u; j < collisionCount; ++j)
             {
                 switch (manifolds[j].otherType)
                 {
@@ -293,7 +293,7 @@ void CrateSystem::airCollision(xy::Entity entity)
 
         if (hitboxes[i].getType() == CollisionType::Crate)
         {
-            for (auto j = 0; j < collisionCount; ++j)
+            for (auto j = 0u; j < collisionCount; ++j)
             {
                 if (manifolds[j].otherType == CollisionType::Teleport)
                 {

--- a/Demo/src/DynamiteSystem.cpp
+++ b/Demo/src/DynamiteSystem.cpp
@@ -81,7 +81,7 @@ void DynamiteSystem::process(float dt)
 
             const auto& collision = entity.getComponent<CollisionComponent>();
             const auto& hitbox = collision.getHitboxes()[0];
-            for (auto i = 0; i < hitbox.getCollisionCount(); ++i)
+            for (auto i = 0u; i < hitbox.getCollisionCount(); ++i)
             {
                 const auto& man = hitbox.getManifolds()[i];
                 if (man.otherType == CollisionType::Teleport)

--- a/Demo/src/GameCompleteState.cpp
+++ b/Demo/src/GameCompleteState.cpp
@@ -94,8 +94,8 @@ bool GameCompleteState::handleEvent(const sf::Event& evt)
     }
     
     if (evt.type == sf::Event::KeyReleased
-        || evt.type == sf::Event::JoystickButtonReleased
-        && inputDelay > 2.f)
+        || (evt.type == sf::Event::JoystickButtonReleased
+            && inputDelay > 2.f))
     {
         //skips to end screen
         if (!m_summaryShown)

--- a/Demo/src/GameState.cpp
+++ b/Demo/src/GameState.cpp
@@ -124,7 +124,7 @@ GameState::GameState(xy::StateStack& stack, xy::State::Context ctx, SharedStateD
     m_scene             (ctx.appInstance.getMessageBus()),
     m_sharedData        (sharedData),
     m_loadingScreen     (ls),
-    m_playerInputs      ({ PlayerInput(m_client, sharedData.inputBindings[0]), PlayerInput(m_client, sharedData.inputBindings[1]) }),
+    m_playerInputs      ({{PlayerInput(m_client, sharedData.inputBindings[0]), PlayerInput(m_client, sharedData.inputBindings[1])}}),
     m_currentMapTexture (0)
 {
     launchLoadingScreen();
@@ -961,7 +961,7 @@ void GameState::handlePacket(const xy::NetEvent& evt)
 
         xy::Command cmd;
         cmd.targetFlags = CommandID::NetActor;
-        cmd.action = [state, this](xy::Entity entity, float)
+        cmd.action = [state](xy::Entity entity, float)
         {
             if (entity.getComponent<Actor>().id == state.actor.id)
             {

--- a/Demo/src/HatSystem.cpp
+++ b/Demo/src/HatSystem.cpp
@@ -197,10 +197,10 @@ void HatSystem::updateSpawning(xy::Entity entity, float dt)
     }
 
     const auto& collision = entity.getComponent<CollisionComponent>();
-    for (auto i = 0; i < collision.getHitboxCount(); ++i)
+    for (auto i = 0u; i < collision.getHitboxCount(); ++i)
     {
         const auto& hitbox = collision.getHitboxes()[i];
-        for (auto j = 0; j < hitbox.getCollisionCount(); ++j)
+        for (auto j = 0u; j < hitbox.getCollisionCount(); ++j)
         {
             const auto& man = hitbox.getManifolds()[j];
             if ((man.otherType == CollisionType::Platform || man.otherType == CollisionType::Solid))
@@ -235,10 +235,10 @@ void HatSystem::updateSpawning(xy::Entity entity, float dt)
 void HatSystem::updateIdle(xy::Entity entity)
 {
     const auto& collision = entity.getComponent<CollisionComponent>();
-    for (auto i = 0; i < collision.getHitboxCount(); ++i)
+    for (auto i = 0u; i < collision.getHitboxCount(); ++i)
     {
         const auto& hitbox = collision.getHitboxes()[i];
-        for (auto j = 0; j < hitbox.getCollisionCount(); ++j)
+        for (auto j = 0u; j < hitbox.getCollisionCount(); ++j)
         {
             const auto& man = hitbox.getManifolds()[j];
             if (man.otherType == CollisionType::Player)
@@ -302,10 +302,10 @@ void HatSystem::updateDying(xy::Entity entity, float dt)
 #endif
 
     const auto& collision = entity.getComponent<CollisionComponent>();
-    for (auto i = 0; i < collision.getHitboxCount(); ++i)
+    for (auto i = 0u; i < collision.getHitboxCount(); ++i)
     {
         const auto& hitbox = collision.getHitboxes()[i];
-        for (auto j = 0; j < hitbox.getCollisionCount(); ++j)
+        for (auto j = 0u; j < hitbox.getCollisionCount(); ++j)
         {
             const auto& man = hitbox.getManifolds()[j];
             if (man.otherType == CollisionType::HardBounds)

--- a/Demo/src/InventoryDirector.cpp
+++ b/Demo/src/InventoryDirector.cpp
@@ -45,7 +45,6 @@ namespace
     const sf::Uint32 PowerupScore = 750;
     const sf::Uint32 GooblyScore = 850;
     const sf::Uint32 SmallFruitScore = 350;
-    const sf::Uint32 LargeFruitScore = 1000;
     const sf::Uint32 BonusScore = 100;
     const sf::Uint32 BonusCompletionScore = 2500;
     const sf::Uint32 HatPickUpScore = 50;

--- a/Demo/src/LoadingScreen.cpp
+++ b/Demo/src/LoadingScreen.cpp
@@ -39,13 +39,13 @@ namespace
     float currFrametime = 0.f;
 
     const std::array<sf::IntRect, 5> frames =
-    {
+    {{
         sf::IntRect( 0,512,128,256 ),
         { 128,512,128,256 },
         { 256,512,128,256 },
         { 384,512,128,256 },
         { 512,512,128,256 }
-    };
+    }};
 }
 
 LoadingScreen::LoadingScreen()

--- a/Demo/src/MapData.hpp
+++ b/Demo/src/MapData.hpp
@@ -149,7 +149,7 @@ namespace InputFlag
 struct InventoryUpdate final
 {
     sf::Uint8 playerID = 0;
-    sf::Uint32 score = 0;
+    sf::Int32 score = 0;
     sf::Uint32 amount = 0;
     sf::Uint8 lives = 0;
     sf::Uint8 bonusFlags = 0;

--- a/Demo/src/MenuCreation.cpp
+++ b/Demo/src/MenuCreation.cpp
@@ -558,20 +558,20 @@ void MenuState::createThirdMenu(xy::Transform& parentTx, sf::Uint32 selectedID, 
 void MenuState::createKeybindInputs(xy::Entity towerEnt, sf::Uint8 player)
 {
     static const std::array<sf::Vector2f, 4u> buttonPositions =
-    {
+    {{
         sf::Vector2f(64.f, 192.f),
         sf::Vector2f(64.f, 448.f),
         sf::Vector2f(64.f, 704.f),
         sf::Vector2f(64.f, 960.f)
-    };
+    }};
 
     static const std::array<sf::Vector2f, 4u> textPositions =
-    {
+    {{
         sf::Vector2f(160.f, 194.f),
         sf::Vector2f(160.f, 450.f),
         sf::Vector2f(160.f, 706.f),
         sf::Vector2f(160.f, 962.f)
-    };
+    }};
 
     auto& towerTx = towerEnt.getComponent<xy::Transform>();
     auto& font = m_fontResource.get("assets/fonts/Cave-Story.ttf");

--- a/Demo/src/MenuState.cpp
+++ b/Demo/src/MenuState.cpp
@@ -193,7 +193,7 @@ void MenuState::loadKeybinds()
     xy::ConfigProperty* property = nullptr;
 
     //-----player one-----//
-    if (property = binds->findProperty("controller_id"))
+    if ((property = binds->findProperty("controller_id")))
     {
         m_sharedStateData.inputBindings[0].controllerID = property->getValue<sf::Int32>();
     }
@@ -204,7 +204,7 @@ void MenuState::loadKeybinds()
         needsUpdate = true;
     }
 
-    if (property = binds->findProperty("left"))
+    if ((property = binds->findProperty("left")))
     {
         m_sharedStateData.inputBindings[0].keys[InputBinding::Left] = static_cast<sf::Keyboard::Key>(property->getValue<sf::Int32>());
     }
@@ -215,7 +215,7 @@ void MenuState::loadKeybinds()
         needsUpdate = true;
     }
 
-    if (property = binds->findProperty("right"))
+    if ((property = binds->findProperty("right")))
     {
         m_sharedStateData.inputBindings[0].keys[InputBinding::Right] = static_cast<sf::Keyboard::Key>(property->getValue<sf::Int32>());
     }
@@ -226,7 +226,7 @@ void MenuState::loadKeybinds()
         needsUpdate = true;
     }
 
-    if (property = binds->findProperty("jump"))
+    if ((property = binds->findProperty("jump")))
     {
         m_sharedStateData.inputBindings[0].keys[InputBinding::Jump] = static_cast<sf::Keyboard::Key>(property->getValue<sf::Int32>());
     }
@@ -237,7 +237,7 @@ void MenuState::loadKeybinds()
         needsUpdate = true;
     }
 
-    if (property = binds->findProperty("shoot"))
+    if ((property = binds->findProperty("shoot")))
     {
         m_sharedStateData.inputBindings[0].keys[InputBinding::Shoot] = static_cast<sf::Keyboard::Key>(property->getValue<sf::Int32>());
     }
@@ -251,7 +251,7 @@ void MenuState::loadKeybinds()
 
     //-----player two-----//
     binds = m_keyBinds.findObjectWithName("player_two");
-    if (property = binds->findProperty("controller_id"))
+    if ((property = binds->findProperty("controller_id")))
     {
         m_sharedStateData.inputBindings[1].controllerID = property->getValue<sf::Int32>();
     }
@@ -262,7 +262,7 @@ void MenuState::loadKeybinds()
         needsUpdate = true;
     }
 
-    if (property = binds->findProperty("left"))
+    if ((property = binds->findProperty("left")))
     {
         m_sharedStateData.inputBindings[1].keys[InputBinding::Left] = static_cast<sf::Keyboard::Key>(property->getValue<sf::Int32>());
     }
@@ -273,7 +273,7 @@ void MenuState::loadKeybinds()
         needsUpdate = true;
     }
 
-    if (property = binds->findProperty("right"))
+    if ((property = binds->findProperty("right")))
     {
         m_sharedStateData.inputBindings[1].keys[InputBinding::Right] = static_cast<sf::Keyboard::Key>(property->getValue<sf::Int32>());
     }
@@ -284,7 +284,7 @@ void MenuState::loadKeybinds()
         needsUpdate = true;
     }
 
-    if (property = binds->findProperty("jump"))
+    if ((property = binds->findProperty("jump")))
     {
         m_sharedStateData.inputBindings[1].keys[InputBinding::Jump] = static_cast<sf::Keyboard::Key>(property->getValue<sf::Int32>());
     }
@@ -295,7 +295,7 @@ void MenuState::loadKeybinds()
         needsUpdate = true;
     }
 
-    if (property = binds->findProperty("shoot"))
+    if ((property = binds->findProperty("shoot")))
     {
         m_sharedStateData.inputBindings[1].keys[InputBinding::Shoot] = static_cast<sf::Keyboard::Key>(property->getValue<sf::Int32>());
     }
@@ -520,12 +520,12 @@ void MenuState::createHelp()
 
     //left tower
     static const std::array<sf::Vector2f, 4u> positions = 
-    {
+    {{
         sf::Vector2f(160.f, 96.f),
         {160.f, 352.f},
         {160.f, 608.f},
         {160.f, 864.f}
-    };
+    }};
     xy::SpriteSheet spriteSheet;
     spriteSheet.loadFromFile("assets/sprites/player.spt", m_textureResource);
 

--- a/Demo/src/MusicCallback.hpp
+++ b/Demo/src/MusicCallback.hpp
@@ -55,11 +55,11 @@ public:
         m_currentTrack  (0)
     {
         m_trackNames = 
-        {
+        {{
             "assets/sound/music/01.ogg",
             "assets/sound/music/02.ogg",
             "assets/sound/music/03.ogg"
-        };
+        }};
     }
 
     void operator () (xy::Entity entity, float dt)

--- a/Demo/src/NPCSystem.cpp
+++ b/Demo/src/NPCSystem.cpp
@@ -47,18 +47,15 @@ namespace
 {
     const float WhirlybobSpeed = 100.f;
     const float ClocksySpeed = 86.f;
-    const float GooblySpeed = 300.f;
     const float BalldockSpeed = 90.f;
     const float BalldockBounceVelocity = 300.f;
     const float SquatmoSpeed = 110.f;
     const float angryMultiplier = 2.f;
     const float initialJumpVelocity = 940.f;
 
-    const std::array<float, 10> thinkTimes = { 20.f, 16.f, 12.f, 31.f, 15.4f, 14.9f, 25.f, 12.7f, 13.3f, 18.f };
+    const std::array<float, 10> thinkTimes = {{ 20.f, 16.f, 12.f, 31.f, 15.4f, 14.9f, 25.f, 12.7f, 13.3f, 18.f }};
     const float BubbleTime = 6.f;
     const float DieTime = 1.5f;
-
-    const sf::Uint32 FootMask = (CollisionType::Platform | CollisionType::Solid | CollisionType::Player);
 
     const float FailSafeTime = 8.f;
 }

--- a/Demo/src/PlayerSystem.cpp
+++ b/Demo/src/PlayerSystem.cpp
@@ -54,8 +54,6 @@ namespace
     const sf::Uint32 UpMask = CollisionFlags::PlayerMask & ~(CollisionFlags::Bubble/*|CollisionFlags::Platform*/);
     const sf::Uint32 DownMask = CollisionFlags::PlayerMask;
 
-    const sf::Uint32 FootMask = (CollisionType::Platform | CollisionType::Solid | CollisionType::Bubble);
-
     const sf::Uint8 BodyClear = 0x1;
     const sf::Uint8 FootClear = 0x2;
     const sf::Uint8 PlayerClear = BodyClear | FootClear;

--- a/Demo/src/PowerupSystem.cpp
+++ b/Demo/src/PowerupSystem.cpp
@@ -50,7 +50,7 @@ namespace
     const sf::Vector2f flameOffset(32.f, 0.f);
     const float flameSpreadTime = 0.5f; //age at which a flame spawns another
 
-    std::array<float, 6u> spawnTimes = { 12.5f, 13.5f, 12.f, 15.f, 14.f, 15.5f };
+    std::array<float, 6u> spawnTimes = {{ 12.5f, 13.5f, 12.f, 15.f, 14.f, 15.5f }};
 }
 
 PowerupSystem::PowerupSystem(xy::MessageBus& mb, xy::NetHost& host)

--- a/Demo/src/Server.cpp
+++ b/Demo/src/Server.cpp
@@ -878,10 +878,10 @@ void GameServer::loadMap()
         //create hard edges - we could probably only do this once
         //as they don't change, but let's stick with the flow
         std::array<sf::FloatRect, 2u> bounds = 
-        {
-            sf::FloatRect(0.f, 0.f, 64.f, MapBounds.height),
-            sf::FloatRect(MapBounds.width - 64.f, 0.f, 64.f, MapBounds.height)
-        };
+        {{
+            sf::FloatRect({0.f, 0.f, 64.f, MapBounds.height}),
+            sf::FloatRect(MapBounds.width - 64.f, 0.f, 64.f, MapBounds.height)   
+        }};
         for (auto rect : bounds)
         {
             auto entity = m_scene.createEntity();

--- a/Demo/src/ServerMessages.hpp
+++ b/Demo/src/ServerMessages.hpp
@@ -50,10 +50,10 @@ namespace MessageIdent
 }
 
 static const std::array<std::string, MessageIdent::Count> serverMessages = 
-{
+{{
     "Stopping server",
     "Failed Loading Map",
     "Client Left Server"
-};
+}};
 
 #endif //DEMO_SERVER_MESSAGES_HPP_

--- a/xyginext/include/xyginext/ecs/Scene.inl
+++ b/xyginext/include/xyginext/ecs/Scene.inl
@@ -90,10 +90,10 @@ T& Scene::addPostProcess(Args&&... args)
     switch (m_postEffects.size())
     {
     case 2:
-        m_postBuffers[0].create(size.x, size.y, false);
+        m_postBuffers[0].create(size.x, size.y);
         break;
     case 3:
-        m_postBuffers[1].create(size.x, size.y, false);
+        m_postBuffers[1].create(size.x, size.y);
         break;
     default: break;
     }

--- a/xyginext/src/audio/Mixer.cpp
+++ b/xyginext/src/audio/Mixer.cpp
@@ -36,7 +36,7 @@ namespace
     
 }
 std::array<std::string, AudioMixer::MaxChannels> AudioMixer::m_labels
-{ 
+{{
     "Channel 0", 
     "Channel 1", 
     "Channel 2", 
@@ -53,10 +53,10 @@ std::array<std::string, AudioMixer::MaxChannels> AudioMixer::m_labels
     "Channel 13", 
     "Channel 14", 
     "Channel 15"
-};
+}};
 
 std::array<float, AudioMixer::MaxChannels> AudioMixer::m_channels
-{ 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f };
+{{ 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f }};
 
 float AudioMixer::m_masterVol = 1.f;
 

--- a/xyginext/src/core/App.cpp
+++ b/xyginext/src/core/App.cpp
@@ -80,7 +80,7 @@ namespace
 bool App::m_mouseCursorVisible = true;
 
 App::App(sf::ContextSettings contextSettings)
-    : m_videoSettings   (),
+    : m_videoSettings   (contextSettings),
     m_renderWindow      (m_videoSettings.VideoMode, windowTitle, m_videoSettings.WindowStyle, m_videoSettings.ContextSettings),
     m_applicationName   (APP_NAME)
 {

--- a/xyginext/src/core/Console.cpp
+++ b/xyginext/src/core/Console.cpp
@@ -293,7 +293,6 @@ void Console::draw()
             useFrameLimit = false;
         }
         
-        bool oldFrameLimit = useFrameLimit;
         nim::Checkbox("Limit Framerate", &useFrameLimit);
         if (useFrameLimit)
         {
@@ -345,7 +344,7 @@ void Console::draw()
         nim::NewLine();
         for (auto& line : m_debugLines)
         {
-            ImGui::Text(line.c_str());
+            ImGui::TextUnformatted(line.c_str());
         }
     }
     m_debugLines.clear();
@@ -546,7 +545,7 @@ int textEditCallback(ImGuiTextEditCallbackData* data)
                 {
                     int c = 0;
                     bool all_candidates_matches = true;
-                    for (int i = 0; i < candidates.size() && all_candidates_matches; i++)
+                    for (auto i = 0u; i < candidates.size() && all_candidates_matches; i++)
                         if (i == 0)
                             c = toupper(candidates[i][match_len]);
                         else if (c == 0 || c != toupper(candidates[i][match_len]))
@@ -583,7 +582,7 @@ int textEditCallback(ImGuiTextEditCallbackData* data)
         {
             if (historyIndex != -1)
             {
-                if (++historyIndex >= history.size())
+                if (++historyIndex >= static_cast<int>(history.size()))
                 {
                     historyIndex = -1;
                 }

--- a/xyginext/src/ecs/Scene.cpp
+++ b/xyginext/src/ecs/Scene.cpp
@@ -131,7 +131,7 @@ void Scene::setPostEnabled(bool enabled)
         
         XY_ASSERT(App::getRenderWindow(), "no valid window");
         auto size = App::getRenderWindow()->getSize();
-        m_sceneBuffer.create(size.x, size.y, true);
+        m_sceneBuffer.create(size.x, size.y, sf::ContextSettings(32));
         for (auto& p : m_postEffects) p->resizeBuffer(size.x, size.y);
     }
     else

--- a/xyginext/src/ecs/systems/UISystem.cpp
+++ b/xyginext/src/ecs/systems/UISystem.cpp
@@ -291,7 +291,7 @@ void UISystem::process(float)
         //-----movement input-----//
         auto area = tx.transformRect(input.area);
         bool contains = false;
-        if (contains = area.contains(m_eventPosition))
+        if ((contains = area.contains(m_eventPosition)))
         {
             if (!input.active)
             {

--- a/xyginext/src/graphics/SpriteSheet.cpp
+++ b/xyginext/src/graphics/SpriteSheet.cpp
@@ -65,13 +65,13 @@ bool SpriteSheet::loadFromFile(const std::string& path, TextureResource& texture
         return false;
     }
 
-    /*if (auto* p = sheetFile.findProperty("blendmode"))
+    if (auto* p = sheetFile.findProperty("blendmode"))
     {
         std::string mode = p->getValue<std::string>();
         if (mode == "add") blendMode = sf::BlendAdd;
         else if (mode == "multiply") blendMode = sf::BlendMultiply;
         else if (mode == "none") blendMode = sf::BlendNone;
-    }*/
+    }
 
     if (auto* p = sheetFile.findProperty("smooth"))
     {

--- a/xyginext/src/util/Random.cpp
+++ b/xyginext/src/util/Random.cpp
@@ -165,5 +165,5 @@ std::vector<sf::Vector2f> xy::Util::Random::poissonDiscDistribution(const sf::Fl
         }
     }
 
-    return std::move(retVal);
+    return retVal;
 }


### PR DESCRIPTION
Including but not limited to:

- SFML deprecating `sf::RenderTexture::create(unsigned int, unsigned int, bool)`. Replaced with `create(unsigned int, unsigned int, sf::ContextSettings)`
- Signed/unsigned mismatch
- Unused variables (I have left a couple of these in, as they are used in commented out code, so may be wanted still)
- Brackets around sub-object inits
- return `std::move` preventing copy elision (I can't claim to 100% understand this fix, but based on what research I've done, it's better not to return `std::move`. Feel free to change this back if you feel otherwise)