### PR TITLE
Initial implementation of handle based resource management

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,18 +52,18 @@ matrix:
     - GENERATOR="Unix Makefiles"
     - CMAKE_FLAGS=""
   - os: osx
-    osx_image: xcode9
+    osx_image: xcode10
     env:
     - GENERATOR="Xcode"
     - CMAKE_FLAGS=""
   - os: osx
-    osx_image: xcode9
+    osx_image: xcode10
     env:
     - GENERATOR="Xcode"
     - CMAKE_FLAGS="-DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/iOS.toolchain.cmake"
   allow_failures:
   - os: osx
-    osx_image: xcode9
+    osx_image: xcode10
     env:
     - GENERATOR="Xcode"
     - CMAKE_FLAGS="-DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/iOS.toolchain.cmake"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_script:
   g++ /usr/bin/g++-7 90; fi
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; brew install enet; fi
 - git clone https://github.com/sfml/sfml && cd sfml
-- git checkout tags/2.5.0
+- git checkout tags/2.5.1
 - mkdir build && cd build
 - cmake .. -G"$GENERATOR" $CMAKE_FLAGS && sudo cmake --build . --target install && cd ../..
 - git clone https://github.com/fallahn/tmxlite

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_script:
 - git clone https://github.com/sfml/sfml && cd sfml
 - git checkout tags/2.5.0
 - mkdir build && cd build
-- cmake .. $CMAKE_FLAGS && sudo cmake --build . --target install && cd ../..
+- cmake .. -G"$GENERATOR" $CMAKE_FLAGS && sudo cmake --build . --target install && cd ../..
 - git clone https://github.com/fallahn/tmxlite
 - cd tmxlite/tmxlite && mkdir build && cd build
 - cmake .. -G"$GENERATOR" $CMAKE_FLAGS -DCMAKE_BUILD_TYPE=Release && sudo cmake --build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,7 @@ if (BUILD_DEMO)
       MACOSX_BUNDLE TRUE
       MACOSX_BUNDLE_ICON_FILE icon.icns
       RESOURCE "${RESOURCE_FILES}")
+  endif(APPLE)
 
   add_dependencies(${DEMO_NAME} ${PROJECT_NAME})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ if (BUILD_DEMO)
 # on macOS and iOS, create a bundle with the resources
   if (APPLE)
     set(RESOURCE_FILES
-      ${CMAKE_SOURCE_DIR}/Demo/assets
+      ${CMAKE_SOURCE_DIR}/Demo/assets/*
       ${CMAKE_SOURCE_DIR}/Demo/macOS/icon.icns)
 
     set_target_properties(${DEMO_NAME} PROPERTIES
@@ -127,7 +127,6 @@ if (BUILD_DEMO)
   
   target_link_libraries(${DEMO_NAME} ${PROJECT_NAME} ${TMXLITE_LIBRARIES} sfml-graphics sfml-audio)
   target_include_directories(${DEMO_NAME} PRIVATE ${TMXLITE_INCLUDE_DIR} $<TARGET_PROPERTY:${PROJECT_NAME},INTERFACE_INCLUDE_DIRECTORIES>)
-  
   
   install(TARGETS ${DEMO_NAME} DESTINATION .)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ option(CMAKE_BUILD_TYPE "Choose the type of build (Debug or Release)" Debug)
 option(BUILD_SHARED_LIBS "Whether to build shared libraries" ON)
 option(BUILD_DEMO "Build the xygine demo" OFF)
 
-# We're using c++14
+# We're using c++17
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -102,16 +102,19 @@ endif()
 # The demo target
 if (BUILD_DEMO)
   add_subdirectory(Demo/src)
+  add_executable(${DEMO_NAME} ${DEMO_SRC})
+
+# on macOS and iOS, create a bundle with the resources
   if (APPLE)
-    set_source_files_properties( 
-    ${CMAKE_SOURCE_DIR}/Demo/assets PROPERTIES MACOSX_PACKAGE_LOCATION Resources )
-    set_source_files_properties(
-    ${CMAKE_SOURCE_DIR}/Demo/macOS/icon.icns PROPERTIES MACOSX_PACKAGE_LOCATION Resources )
-    add_executable(${DEMO_NAME} MACOSX_BUNDLE ${DEMO_SRC} ${CMAKE_SOURCE_DIR}/Demo/assets ${CMAKE_SOURCE_DIR}/Demo/macOS/icon.icns)
-    set_target_properties(${DEMO_NAME} PROPERTIES MACOSX_BUNDLE_ICON_FILE icon.icns)
-  else()
-    add_executable(${DEMO_NAME} ${DEMO_SRC})
-  endif()
+    set(RESOURCE_FILES
+      ${CMAKE_SOURCE_DIR}/Demo/assets
+      ${CMAKE_SOURCE_DIR}/Demo/macOS/icon.icns)
+
+    set_target_properties(${DEMO_NAME} PROPERTIES
+      MACOSX_BUNDLE TRUE
+      MACOSX_BUNDLE_ICON_FILE icon.icns
+      RESOURCE "${RESOURCE_FILES}")
+
   add_dependencies(${DEMO_NAME} ${PROJECT_NAME})
 
   find_package(TMXLITE REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,8 @@ option(CMAKE_BUILD_TYPE "Choose the type of build (Debug or Release)" Debug)
 option(BUILD_SHARED_LIBS "Whether to build shared libraries" ON)
 option(BUILD_DEMO "Build the xygine demo" OFF)
 
-# We're using c++14
-set(CMAKE_CXX_STANDARD 14)
+# We're using c++17
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # enable some warnings in debug builds with gcc/clang

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,8 @@ option(CMAKE_BUILD_TYPE "Choose the type of build (Debug or Release)" Debug)
 option(BUILD_SHARED_LIBS "Whether to build shared libraries" ON)
 option(BUILD_DEMO "Build the xygine demo" OFF)
 
-# We're using c++17
-set(CMAKE_CXX_STANDARD 17)
+# We're using c++14
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # enable some warnings in debug builds with gcc/clang
@@ -102,20 +102,16 @@ endif()
 # The demo target
 if (BUILD_DEMO)
   add_subdirectory(Demo/src)
-  add_executable(${DEMO_NAME} ${DEMO_SRC})
-
-# on macOS and iOS, create a bundle with the resources
   if (APPLE)
-    set(RESOURCE_FILES
-      ${CMAKE_SOURCE_DIR}/Demo/assets/*
-      ${CMAKE_SOURCE_DIR}/Demo/macOS/icon.icns)
-
-    set_target_properties(${DEMO_NAME} PROPERTIES
-      MACOSX_BUNDLE TRUE
-      MACOSX_BUNDLE_ICON_FILE icon.icns
-      RESOURCE "${RESOURCE_FILES}")
-  endif(APPLE)
-
+    set_source_files_properties( 
+    ${CMAKE_SOURCE_DIR}/Demo/assets PROPERTIES MACOSX_PACKAGE_LOCATION Resources )
+    set_source_files_properties(
+    ${CMAKE_SOURCE_DIR}/Demo/macOS/icon.icns PROPERTIES MACOSX_PACKAGE_LOCATION Resources )
+    add_executable(${DEMO_NAME} MACOSX_BUNDLE ${DEMO_SRC} ${CMAKE_SOURCE_DIR}/Demo/assets ${CMAKE_SOURCE_DIR}/Demo/macOS/icon.icns)
+    set_target_properties(${DEMO_NAME} PROPERTIES MACOSX_BUNDLE_ICON_FILE icon.icns)
+  else()
+    add_executable(${DEMO_NAME} ${DEMO_SRC})
+  endif()
   add_dependencies(${DEMO_NAME} ${PROJECT_NAME})
 
   find_package(TMXLITE REQUIRED)
@@ -127,6 +123,7 @@ if (BUILD_DEMO)
   
   target_link_libraries(${DEMO_NAME} ${PROJECT_NAME} ${TMXLITE_LIBRARIES} sfml-graphics sfml-audio)
   target_include_directories(${DEMO_NAME} PRIVATE ${TMXLITE_INCLUDE_DIR} $<TARGET_PROPERTY:${PROJECT_NAME},INTERFACE_INCLUDE_DIRECTORIES>)
+  
   
   install(TARGETS ${DEMO_NAME} DESTINATION .)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ option(BUILD_SHARED_LIBS "Whether to build shared libraries" ON)
 option(BUILD_DEMO "Build the xygine demo" OFF)
 
 # We're using c++14
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # enable some warnings in debug builds with gcc/clang

--- a/Demo/Demo.vcxproj
+++ b/Demo/Demo.vcxproj
@@ -80,6 +80,7 @@
       <AdditionalIncludeDirectories>$(SolutionDir)extlibs\include;$(SolutionDir)xyginext\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_ITERATOR_DEBUG_LEVEL=0;XY_DEBUG;_CRT_SECURE_NO_WARNINGS;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(SolutionDir)extlibs\bin\msvc_x64\sfml\Debug;$(SolutionDir)x64\Debug;$(SolutionDir)extlibs\bin\msvc_x64\tmxlite\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
@@ -116,6 +117,7 @@
       <AdditionalIncludeDirectories>$(SolutionDir)extlibs\include;$(SolutionDir)xyginext\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/Demo/src/MenuCreation.cpp
+++ b/Demo/src/MenuCreation.cpp
@@ -57,7 +57,7 @@ void MenuState::createFirstMenu(xy::Transform& parentTx, sf::Uint32 selectedID, 
 
     //one player button
     entity = m_scene.createEntity();
-    entity.addComponent<xy::Sprite>().setTexture(m_textureResource.get("assets/images/button.png"));
+    entity.addComponent<xy::Sprite>().setTexture(m_resource.get<sf::Texture>(m_buttonRes));
     bounds = entity.getComponent<xy::Sprite>().getTextureBounds();
     entity.getComponent<xy::Sprite>().setTextureRect({ 0.f, 0.f, bounds.width, bounds.height / 4.f });
     entity.addComponent<xy::Drawable>();
@@ -116,7 +116,7 @@ void MenuState::createFirstMenu(xy::Transform& parentTx, sf::Uint32 selectedID, 
 
     //multiplayer button
     entity = m_scene.createEntity();
-    entity.addComponent<xy::Sprite>().setTexture(m_textureResource.get("assets/images/button.png"));
+    entity.addComponent<xy::Sprite>().setTexture(m_resource.get<sf::Texture>(m_buttonRes));
     bounds = entity.getComponent<xy::Sprite>().getTextureBounds();
     entity.getComponent<xy::Sprite>().setTextureRect({ 0.f, 0.f, bounds.width, bounds.height / 4.f });
     entity.addComponent<xy::Drawable>();
@@ -168,7 +168,7 @@ void MenuState::createFirstMenu(xy::Transform& parentTx, sf::Uint32 selectedID, 
 
     //quit button
     entity = m_scene.createEntity();
-    entity.addComponent<xy::Sprite>().setTexture(m_textureResource.get("assets/images/button.png"));
+    entity.addComponent<xy::Sprite>().setTexture(m_resource.get<sf::Texture>(m_buttonRes));
     bounds = entity.getComponent<xy::Sprite>().getTextureBounds();
     entity.getComponent<xy::Sprite>().setTextureRect({ 0.f, 0.f, bounds.width, bounds.height / 4.f });
     entity.addComponent<xy::Drawable>();
@@ -227,7 +227,7 @@ void MenuState::createSecondMenu(xy::Transform& parentTx, sf::Uint32 selectedID,
 
     //local button
     entity = m_scene.createEntity();
-    entity.addComponent<xy::Sprite>().setTexture(m_textureResource.get("assets/images/button.png"));
+    entity.addComponent<xy::Sprite>().setTexture(m_resource.get<sf::Texture>(m_buttonRes));
     bounds = entity.getComponent<xy::Sprite>().getTextureBounds();
     entity.getComponent<xy::Sprite>().setTextureRect({ 0.f, 0.f, bounds.width, bounds.height / 4.f });
     entity.addComponent<xy::Drawable>();
@@ -286,7 +286,7 @@ void MenuState::createSecondMenu(xy::Transform& parentTx, sf::Uint32 selectedID,
 
     //network button
     entity = m_scene.createEntity();
-    entity.addComponent<xy::Sprite>().setTexture(m_textureResource.get("assets/images/button.png"));
+    entity.addComponent<xy::Sprite>().setTexture(m_resource.get<sf::Texture>(m_buttonRes));
     bounds = entity.getComponent<xy::Sprite>().getTextureBounds();
     entity.getComponent<xy::Sprite>().setTextureRect({ 0.f, 0.f, bounds.width, bounds.height / 4.f });
     entity.addComponent<xy::Drawable>();
@@ -341,7 +341,7 @@ void MenuState::createSecondMenu(xy::Transform& parentTx, sf::Uint32 selectedID,
 
     //back button
     entity = m_scene.createEntity();
-    entity.addComponent<xy::Sprite>().setTexture(m_textureResource.get("assets/images/button.png"));
+    entity.addComponent<xy::Sprite>().setTexture(m_resource.get<sf::Texture>(m_buttonRes));
     bounds = entity.getComponent<xy::Sprite>().getTextureBounds();
     entity.getComponent<xy::Sprite>().setTextureRect({ 0.f, 0.f, bounds.width, bounds.height / 4.f });
     entity.addComponent<xy::Drawable>();
@@ -397,7 +397,7 @@ void MenuState::createThirdMenu(xy::Transform& parentTx, sf::Uint32 selectedID, 
 
     //host button
     entity = m_scene.createEntity();
-    entity.addComponent<xy::Sprite>().setTexture(m_textureResource.get("assets/images/button.png"));
+    entity.addComponent<xy::Sprite>().setTexture(m_resource.get<sf::Texture>(m_buttonRes));
     bounds = entity.getComponent<xy::Sprite>().getTextureBounds();
     entity.getComponent<xy::Sprite>().setTextureRect({ 0.f, 0.f, bounds.width, bounds.height / 4.f });
     entity.addComponent<xy::Drawable>();
@@ -466,7 +466,7 @@ void MenuState::createThirdMenu(xy::Transform& parentTx, sf::Uint32 selectedID, 
 
     //join button
     entity = m_scene.createEntity();
-    entity.addComponent<xy::Sprite>().setTexture(m_textureResource.get("assets/images/button.png"));
+    entity.addComponent<xy::Sprite>().setTexture(m_resource.get<sf::Texture>(m_buttonRes));
     bounds = entity.getComponent<xy::Sprite>().getTextureBounds();
     entity.getComponent<xy::Sprite>().setTextureRect({ 0.f, 0.f, bounds.width, bounds.height / 2.f });
     entity.addComponent<xy::Drawable>();
@@ -525,7 +525,7 @@ void MenuState::createThirdMenu(xy::Transform& parentTx, sf::Uint32 selectedID, 
 
     //back button
     entity = m_scene.createEntity();
-    entity.addComponent<xy::Sprite>().setTexture(m_textureResource.get("assets/images/button.png"));
+    entity.addComponent<xy::Sprite>().setTexture(m_resource.get<sf::Texture>(m_buttonRes));
     bounds = entity.getComponent<xy::Sprite>().getTextureBounds();
     entity.getComponent<xy::Sprite>().setTextureRect({ 0.f, 0.f, bounds.width, bounds.height / 4.f });
     entity.addComponent<xy::Drawable>();
@@ -584,7 +584,7 @@ void MenuState::createKeybindInputs(xy::Entity towerEnt, sf::Uint8 player)
     }};
 
     auto& towerTx = towerEnt.getComponent<xy::Transform>();
-    auto& font = m_fontResource.get("assets/fonts/Cave-Story.ttf");
+    auto& font = m_resource.get<sf::Font>(m_caveStoryRes);
 
     for (auto i = 0u; i < 4u; ++i)
     {

--- a/Demo/src/MenuDirector.cpp
+++ b/Demo/src/MenuDirector.cpp
@@ -35,7 +35,7 @@ source distribution.
 #include <xyginext/ecs/components/Drawable.hpp>
 #include <xyginext/ecs/components/QuadTreeItem.hpp>
 #include <xyginext/graphics/SpriteSheet.hpp>
-#include <xyginext/resources/Resource.hpp>
+#include <xyginext/resources/ResourceHandler.hpp>
 
 #include <xyginext/util/Random.hpp>
 
@@ -133,7 +133,7 @@ namespace
     };
 }
 
-MenuDirector::MenuDirector(xy::TextureResource& tr)
+MenuDirector::MenuDirector(xy::ResourceHandler& tr)
     : m_currentAct  (0),
     m_timer         (5.f),
     m_acts          (19)

--- a/Demo/src/MenuDirector.hpp
+++ b/Demo/src/MenuDirector.hpp
@@ -35,13 +35,13 @@ source distribution.
 
 namespace xy
 {
-    class TextureResource;
+    class ResourceHandler;
 }
 
 class MenuDirector final : public xy::Director
 {
 public:
-    explicit MenuDirector(xy::TextureResource&);
+    explicit MenuDirector(xy::ResourceHandler&);
 
     void handleMessage(const xy::Message&) override {}
 

--- a/Demo/src/MenuState.cpp
+++ b/Demo/src/MenuState.cpp
@@ -82,6 +82,15 @@ MenuState::MenuState(xy::StateStack& stack, xy::State::Context ctx, SharedStateD
     : xy::State(stack, ctx),
     m_scene             (ctx.appInstance.getMessageBus()),
     m_helpScene         (ctx.appInstance.getMessageBus()),
+    m_resource          (),
+    m_menuBGRes         (m_resource.load<sf::Texture>("assets/images/menu_background.png")),
+    m_grassRes          (m_resource.load<sf::Texture>("assets/images/grass.png")),
+    m_flowerRes         (m_resource.load<sf::Texture>("assets/images/flower.png")),
+    m_helpSignRes       (m_resource.load<sf::Texture>("assets/images/help_sign.png")),
+    m_caveStoryRes      (m_resource.load<sf::Font>("assets/fonts/Cave-Story.ttf")),
+    m_helpRes           (m_resource.load<sf::Texture>("assets/images/help.png")),
+    m_keyBindsRes       (m_resource.load<sf::Texture>("assets/images/keybinds.png")),
+    m_buttonRes         (m_resource.load<sf::Texture>("assets/images/button.png")),
     m_sharedStateData   (sharedData),
     m_loadingScreen     (ls),
     m_helpShown         (false),
@@ -330,7 +339,7 @@ void MenuState::createScene()
     m_scene.addSystem<xy::RenderSystem>(mb);
     m_scene.addSystem<xy::ParticleSystem>(mb);
     m_scene.addDirector<TextboxDirector>(m_sharedStateData);
-    m_scene.addDirector<MenuDirector>(m_textureResource);
+    m_scene.addDirector<MenuDirector>(m_resource);
 
     m_blurEffect = &m_scene.addPostProcess<xy::PostBlur>();
     m_blurEffect->setFadeSpeed(2.5f);
@@ -341,7 +350,7 @@ void MenuState::createScene()
     //background
     auto entity = m_scene.createEntity();
     entity.addComponent<xy::Transform>();
-    entity.addComponent<xy::Sprite>(m_textureResource.get("assets/images/menu_background.png"));
+    entity.addComponent<xy::Sprite>().setTexture(m_resource.get<sf::Texture>(m_menuBGRes));
     entity.addComponent<xy::Drawable>().setDepth(-10);
 
     xy::AudioScape as(m_audioResource);
@@ -354,11 +363,11 @@ void MenuState::createScene()
 
     //grass at front
     entity = m_scene.createEntity();
-    auto bounds = entity.addComponent<xy::Sprite>(m_textureResource.get("assets/images/grass.png")).getTextureBounds();
+    auto bounds = entity.addComponent<xy::Sprite>(m_resource.get<sf::Texture>(m_grassRes)).getTextureBounds();
     bounds.width = xy::DefaultSceneSize.x;
     entity.addComponent<xy::Transform>().setPosition(0.f, xy::DefaultSceneSize.y - (bounds.height * 0.9f));
     entity.getComponent<xy::Sprite>().setTextureRect(bounds);
-    m_textureResource.get("assets/images/grass.png").setRepeated(true);
+    m_resource.get<sf::Texture>(m_grassRes).setRepeated(true);
     entity.addComponent<xy::Drawable>().setDepth(10);
 
 #ifndef XY_DEBUG
@@ -382,7 +391,7 @@ void MenuState::createScene()
         entity.getComponent<SpringFlower>().mass = 0.4f;
         entity.getComponent<SpringFlower>().stiffness = -28.f;
         entity.getComponent<SpringFlower>().damping = -0.4f;
-        entity.addComponent<xy::Drawable>(m_textureResource.get("assets/images/grass.png"));
+        entity.addComponent<xy::Drawable>(m_resource.get<sf::Texture>(m_grassRes));
         entity.addComponent<xy::Transform>().setPosition(xPos, xy::DefaultSceneSize.y - xy::Util::Random::value(5.f, 11.f));
 
         xPos += xy::Util::Random::value(80.f, 112.f);
@@ -398,7 +407,7 @@ void MenuState::createScene()
         entity.addComponent<SpringFlower>(-256.f).headPos.x += xy::Util::Random::value(-12.f, 14.f);
         entity.getComponent<SpringFlower>().textureRect = { 0.f, 0.f, 64.f, 256.f };
         entity.getComponent<SpringFlower>().colour = { darkness, darkness, darkness };
-        entity.addComponent<xy::Drawable>(m_textureResource.get("assets/images/flower.png")).setDepth(depth);
+        entity.addComponent<xy::Drawable>(m_resource.get<sf::Texture>(m_flowerRes)).setDepth(depth);
         entity.addComponent<xy::Transform>().setPosition(xPos, xy::DefaultSceneSize.y + xy::Util::Random::value(0.f, 64.f));
 
         if ((i%4) == 0)
@@ -418,7 +427,7 @@ void MenuState::createScene()
 
     //help sign
     entity = m_scene.createEntity();
-    bounds = entity.addComponent<xy::Sprite>(m_textureResource.get("assets/images/help_sign.png")).getTextureBounds();
+    bounds = entity.addComponent<xy::Sprite>(m_resource.get<sf::Texture>(m_helpSignRes)).getTextureBounds();
     entity.addComponent<xy::Transform>().setPosition(xy::DefaultSceneSize.x - (bounds.width + 202.f), xy::DefaultSceneSize.y - bounds.height);
     entity.addComponent<xy::Drawable>().setDepth(9);
     entity.addComponent<xy::UIHitBox>().callbacks[xy::UIHitBox::MouseUp] =
@@ -456,7 +465,7 @@ void MenuState::createMenu()
     });
     
 
-    auto& font = m_fontResource.get("assets/fonts/Cave-Story.ttf");
+    auto& font = m_resource.get<sf::Font>(m_caveStoryRes);
     auto parentEnt = m_scene.createEntity();
     auto& tx = parentEnt.addComponent<xy::Transform>();
     parentEnt.addComponent<xy::Callback>().active = true;
@@ -505,7 +514,7 @@ void MenuState::createHelp()
 
     //help menu
     entity = m_helpScene.createEntity();
-    entity.addComponent<xy::Sprite>(m_textureResource.get("assets/images/help.png"));
+    entity.addComponent<xy::Sprite>(m_resource.get<sf::Texture>(m_helpRes));
     entity.addComponent<xy::Drawable>();
     entity.addComponent<xy::Transform>().setPosition(0.f, HelpMenuCallback::HidePosition);
     entity.getComponent<xy::Transform>().addChild(tx);
@@ -514,8 +523,15 @@ void MenuState::createHelp()
 
     //background
     entity = m_helpScene.createEntity();
-    m_textureResource.setFallbackColour(sf::Color::White);
-    auto size = entity.addComponent<xy::Sprite>(m_textureResource.get("help_background")).getSize();
+    m_resource.getLoader<sf::Texture>().fallback = ([]()
+    {
+        sf::Texture t;
+        sf::Image i;
+        i.create(20u, 20u, sf::Color::White);
+        t.loadFromImage(i);
+        return stdx::any(t);
+    });
+    auto size = entity.addComponent<xy::Sprite>(m_resource.get<sf::Texture>(0)).getSize();
     entity.addComponent<xy::Transform>().setScale(xy::DefaultSceneSize.x / size.x, xy::DefaultSceneSize.y / size.y);
     entity.addComponent<xy::Drawable>().setDepth(-1);
     entity.getComponent<xy::Sprite>().setColour(sf::Color::Transparent);
@@ -531,10 +547,10 @@ void MenuState::createHelp()
         {160.f, 864.f}
     }};
     xy::SpriteSheet spriteSheet;
-    spriteSheet.loadFromFile("assets/sprites/player.spt", m_textureResource);
+    spriteSheet.loadFromFile("assets/sprites/player.spt", m_resource);
 
     auto towerEnt = m_helpScene.createEntity();
-    auto bounds = towerEnt.addComponent<xy::Sprite>(m_textureResource.get("assets/images/keybinds.png")).getTextureBounds();
+    auto bounds = towerEnt.addComponent<xy::Sprite>(m_resource.get<sf::Texture>(m_keyBindsRes)).getTextureBounds();
     towerEnt.addComponent<xy::Drawable>().setDepth(1);
     auto& towerLeftTx = towerEnt.addComponent<xy::Transform>();
     towerEnt.addComponent<xy::Callback>().function = MenuSliderCallback(m_leftMenuTarget);
@@ -582,7 +598,7 @@ void MenuState::createHelp()
 
     //right tower
     towerEnt = m_helpScene.createEntity();
-    bounds = towerEnt.addComponent<xy::Sprite>(m_textureResource.get("assets/images/keybinds.png")).getTextureBounds();
+    bounds = towerEnt.addComponent<xy::Sprite>(m_resource.get<sf::Texture>(m_keyBindsRes)).getTextureBounds();
     towerEnt.addComponent<xy::Drawable>().setDepth(1);
     auto& towerRightTx = towerEnt.addComponent<xy::Transform>();
     towerEnt.addComponent<xy::Callback>().function = MenuSliderCallback(m_rightMenuTarget);
@@ -637,7 +653,7 @@ To Change It)";
 
     entity = m_helpScene.createEntity();
     entity.addComponent<xy::Transform>().setPosition(364.f, xy::DefaultSceneSize.y);
-    entity.addComponent<xy::Text>(m_fontResource.get("assets/fonts/Cave-Story.ttf")).setFillColour({ 127, 127, 127 });
+    entity.addComponent<xy::Text>(m_resource.get<sf::Font>(m_caveStoryRes)).setFillColour({ 127, 127, 127 });
     entity.getComponent<xy::Text>().setString(helpText);
     entity.getComponent<xy::Text>().setCharacterSize(60u);
     entity.addComponent<xy::Drawable>().setDepth(2);

--- a/Demo/src/MenuState.cpp
+++ b/Demo/src/MenuState.cpp
@@ -529,7 +529,7 @@ void MenuState::createHelp()
         sf::Image i;
         i.create(20u, 20u, sf::Color::White);
         t.loadFromImage(i);
-        return stdx::any(t);
+        return std::any(t);
     });
     auto size = entity.addComponent<xy::Sprite>(m_resource.get<sf::Texture>(0)).getSize();
     entity.addComponent<xy::Transform>().setScale(xy::DefaultSceneSize.x / size.x, xy::DefaultSceneSize.y / size.y);

--- a/Demo/src/MenuState.hpp
+++ b/Demo/src/MenuState.hpp
@@ -31,6 +31,9 @@ source distribution.
 #include <xyginext/core/ConfigFile.hpp>
 #include <xyginext/ecs/Scene.hpp>
 #include <xyginext/resources/Resource.hpp>
+#include <xyginext/resources/ResourceHandler.hpp>
+
+#include <SFML/Graphics/Font.hpp>
 
 #include "StateIDs.hpp"
 #include "SharedStateData.hpp"
@@ -58,9 +61,19 @@ public:
 private:
     xy::Scene m_scene;
     xy::Scene m_helpScene;
-    xy::FontResource m_fontResource;
-    xy::TextureResource m_textureResource;
+
     xy::AudioResource m_audioResource;
+    xy::ResourceHandler m_resource;
+    
+    // Handles to resources we'll use
+    xy::ResourceHandle  m_menuBGRes,
+                        m_grassRes,
+                        m_flowerRes,
+                        m_helpSignRes,
+                        m_caveStoryRes,
+                        m_helpRes,
+                        m_keyBindsRes,
+                        m_buttonRes;
 
     SharedStateData& m_sharedStateData;
     LoadingScreen& m_loadingScreen;

--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,10 @@ development of systems with a data-driven approach, as well as the
 removal of 3D support. If you're interested in a 3D, crossplatform, mobile
 compatible framework with a very similar API, check out [crogine](https://github.com/fallahn/crogine).
 
+xygine uses C++17 features so an up to date compiler is required, for
+example XCode 10 on macOS, Visual Studio 2017 on windows or recent versions
+of gcc and clang.
+
 ###### What's new?
 All new modular ECS providing a flexible and performant API for implementing
 custom components and systems, which compliment the systems included in the library

--- a/xyginext/include/xyginext/CMakeLists.txt
+++ b/xyginext/include/xyginext/CMakeLists.txt
@@ -73,6 +73,8 @@ set(PROJECT_SRC  ${PROJECT_SRC}
   ${CMAKE_CURRENT_SOURCE_DIR}/network/NetImpl.hpp
 
   ${CMAKE_CURRENT_SOURCE_DIR}/resources/Resource.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/resources/DejaVuSans.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/resources/ResourceHandler.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/resources/ShaderResource.hpp
   
   ${CMAKE_CURRENT_SOURCE_DIR}/util/Random.hpp

--- a/xyginext/include/xyginext/Config.hpp
+++ b/xyginext/include/xyginext/Config.hpp
@@ -34,6 +34,7 @@ source distribution.
 
 //windows compilers need specific (and different) keywords for export
 #define XY_EXPORT_API __declspec(dllexport)
+#define XY_IMPORT_API __declspec(dllimport)
 
 //for vc compilers we also need to turn off this annoying C4251 warning
 #ifdef _MSC_VER
@@ -47,11 +48,12 @@ source distribution.
 //gcc 4 has special keywords for showing/hiding symbols,
 //the same keyword is used for both importing and exporting
 #define XY_EXPORT_API __attribute__ ((__visibility__ ("default")))
-
+#define XY_IMPORT_API __attribute__ ((__visibility__ ("default")))
 #else
 
 //gcc < 4 has no mechanism to explicitly hide symbols, everything's exported
 #define XY_EXPORT_API
+#define XY_IMPORT_API
 #endif //__GNUC__
 
 #endif //_WIN32
@@ -60,7 +62,7 @@ source distribution.
 
 //static build doesn't need import/export macros
 #define XY_EXPORT_API
-
+#define XY_IMPORT_API
 #endif //XY_STATIC
 
 //xygine-wide consts

--- a/xyginext/include/xyginext/ecs/components/ParticleEmitter.hpp
+++ b/xyginext/include/xyginext/ecs/components/ParticleEmitter.hpp
@@ -45,6 +45,7 @@ namespace sf
 namespace xy
 {
     class TextureResource;
+    class ResourceHandler;
 
     /*!
     \brief Represents a single particle in a system
@@ -85,6 +86,7 @@ namespace xy
         sf::Int32 releaseCount = 0; //! <number of particles release before stopping (0 for infinite)
         sf::Texture* texture = nullptr;
         bool loadFromFile(const std::string&, TextureResource&);
+        bool loadFromFile(const std::string&, ResourceHandler&);
     };
 
     /*!

--- a/xyginext/include/xyginext/ecs/components/Sprite.hpp
+++ b/xyginext/include/xyginext/ecs/components/Sprite.hpp
@@ -28,6 +28,7 @@ source distribution.
 #pragma once
 
 #include "xyginext/Config.hpp"
+#include "xyginext/resources/ResourceHandler.hpp"
 
 #include <SFML/Graphics/RenderStates.hpp>
 #include <SFML/Graphics/Vertex.hpp>
@@ -57,12 +58,14 @@ namespace xy
         \brief Construct a sprite with a texture
         */
         explicit Sprite(const sf::Texture&);
+        //explicit Sprite(const xy::ResourceHandle&);
 
         /*!
         \brief Sets the texture with which to draw this sprite.
         By default sprites are resized to the size of this texture
         */
         void setTexture(const sf::Texture&);
+        //void setTexture(const xy::ResourceHandle&);
 
         /*!
         \brief Sets a sub rectangle of the current texture
@@ -154,6 +157,7 @@ namespace xy
 
         sf::FloatRect m_textureRect;
         const sf::Texture* m_texture;
+        ResourceHandle  m_textureHandle;
         sf::Color m_colour;
         bool m_dirty;
 

--- a/xyginext/include/xyginext/graphics/SpriteSheet.hpp
+++ b/xyginext/include/xyginext/graphics/SpriteSheet.hpp
@@ -36,6 +36,7 @@ source distribution.
 namespace xy
 {
     class TextureResource;
+    class ResourceHandler;
 
     /*!
     \brief Supports loading multiple sprites from a single
@@ -53,6 +54,7 @@ namespace xy
         \returns true if successful, else false
         */
         bool loadFromFile(const std::string& path, TextureResource& rx);
+        bool loadFromFile(const std::string& path, ResourceHandler& rx);
 
         /*!
         \brief Attempts to save a ConfigFile at the given path.

--- a/xyginext/include/xyginext/resources/DejaVuSans.hpp
+++ b/xyginext/include/xyginext/resources/DejaVuSans.hpp
@@ -27,8 +27,9 @@ source distribution.
 
 #pragma once
 
+#include "xyginext/Config.hpp"
 #include <array>
 
 
-constexpr unsigned int DejaVuSans_Size = 720856;
-extern std::array<unsigned char, DejaVuSans_Size> DejaVuSans_ttf;
+static constexpr unsigned int DejaVuSans_Size = 720856;
+extern const std::array<unsigned char, DejaVuSans_Size> DejaVuSans_ttf;

--- a/xyginext/include/xyginext/resources/DejaVuSans.hpp
+++ b/xyginext/include/xyginext/resources/DejaVuSans.hpp
@@ -1,0 +1,34 @@
+/*********************************************************************
+(c) Matt Marchant 2017 - 2018
+http://trederia.blogspot.com
+
+xygineXT - Zlib license.
+
+This software is provided 'as-is', without any express or
+implied warranty. In no event will the authors be held
+liable for any damages arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute
+it freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented;
+you must not claim that you wrote the original software.
+If you use this software in a product, an acknowledgment
+in the product documentation would be appreciated but
+is not required.
+
+2. Altered source versions must be plainly marked as such,
+and must not be misrepresented as being the original software.
+
+3. This notice may not be removed or altered from any
+source distribution.
+*********************************************************************/
+
+#pragma once
+
+#include <array>
+
+
+constexpr unsigned int DejaVuSans_Size = 720856;
+extern std::array<unsigned char, DejaVuSans_Size> DejaVuSans_ttf;

--- a/xyginext/include/xyginext/resources/ResourceHandler.hpp
+++ b/xyginext/include/xyginext/resources/ResourceHandler.hpp
@@ -1,6 +1,5 @@
 /*********************************************************************
-(c) Matt Marchant 2017 - 2018
-http://trederia.blogspot.com
+(c) Jonny Paton 2018
 
 xygineXT - Zlib license.
 
@@ -63,7 +62,7 @@ namespace xy
      
      Basically just an index to the resource in the vector
      */
-    using ResourceHandle = std::uint16_t;
+    using ResourceHandle = std::size_t;
     
     /*!
      \brief Struct responsible for loading resources
@@ -155,7 +154,7 @@ namespace xy
          Get a resource from it's handle
          */
         template<class T>
-        T& get(const ResourceHandle& resource)
+        T& get(ResourceHandle resource)
         {
             XY_ASSERT(resource < m_resources.size(), "Invalid resource handle");
             return *stdx::any_cast<T>(&m_resources[resource]);
@@ -171,6 +170,14 @@ namespace xy
         ResourceLoader& getLoader()
         {
             return m_loaders[typeid(T)];
+        }
+        
+        template<class T>
+        const ResourceLoader& getLoader() const
+        {
+            const auto found = m_loaders.find(typeid(T));
+            XY_ASSERT(found != m_loaders.end(), "Requested loader not found");
+            return found->second;
         }
         
     private:

--- a/xyginext/include/xyginext/resources/ResourceHandler.hpp
+++ b/xyginext/include/xyginext/resources/ResourceHandler.hpp
@@ -87,39 +87,7 @@ namespace xy
     public:
         
         // Constructor
-        ResourceHandler()
-        {
-            // Add a texture loader
-            ResourceLoader texLoader;
-            texLoader.loader = [](const std::string& path)
-            {
-                sf::Texture tex;
-                return tex.loadFromFile(path) ? tex : stdx::any();
-            };
-            
-            texLoader.fallback = []()
-            {
-                return sf::Texture();
-            };
-            
-            // And a font loader
-            ResourceLoader fontLoader;
-            fontLoader.loader = [](const std::string& path)
-            {
-                sf::Font font;
-                return font.loadFromFile(path) ? font : stdx::any();
-            };
-            
-            fontLoader.fallback = []()
-            {
-                sf::Font font;
-                font.loadFromMemory(DejaVuSans_ttf.data(), DejaVuSans_Size);
-                return font;
-            };
-            
-            getLoader<sf::Texture>() = texLoader;
-            getLoader<sf::Font>() = fontLoader;
-        }
+        ResourceHandler();
         
         /*!
          \brief Load a resource

--- a/xyginext/include/xyginext/resources/ResourceHandler.hpp
+++ b/xyginext/include/xyginext/resources/ResourceHandler.hpp
@@ -26,16 +26,10 @@ source distribution.
 
 #pragma once
 
-#include "xyginext/core/Log.hpp"
 #include "xyginext/core/Assert.hpp"
-#include "xyginext/resources/DejaVuSans.hpp"
 
-#include <SFML/Graphics/Texture.hpp>
-#include <SFML/Graphics/Font.hpp>
-
-#include <unordered_map>
-#include <vector>
 #include <typeindex>
+#include <unordered_map>
 
 // Fiddling for experimental features
 #if __has_include(<any>)

--- a/xyginext/include/xyginext/resources/ResourceHandler.hpp
+++ b/xyginext/include/xyginext/resources/ResourceHandler.hpp
@@ -30,24 +30,7 @@ source distribution.
 
 #include <typeindex>
 #include <unordered_map>
-
-// Fiddling for experimental features
-#if __has_include(<any>)
-
 #include <any>
-namespace stdx {
-    using namespace ::std;
-}
-#elif __has_include(<experimental/any>)
-#include <experimental/any>
-namespace stdx {
-    using namespace ::std;
-    using namespace ::std::experimental;
-}
-
-#else
-#error <experimental/any> and <any> not found
-#endif
 
 namespace xy
 {
@@ -65,8 +48,8 @@ namespace xy
      */
     struct ResourceLoader
     {
-        std::function<stdx::any(const std::string&)>   loader;
-        std::function<stdx::any()>                     fallback;
+        std::function<std::any(const std::string&)>   loader;
+        std::function<std::any()>                     fallback;
     };
     
     /*!
@@ -99,11 +82,7 @@ namespace xy
             m_resources.emplace_back(m_loaders[ti].loader(path));
             
             // If it wasn't loaded, use fallback
-            #ifdef __APPLE__
-            if (m_resources.back().empty())
-            #else
             if (!m_resources.back().has_value())
-            #endif
             {
                 m_resources.back() = m_loaders[ti].fallback();
             }
@@ -119,7 +98,7 @@ namespace xy
         T& get(ResourceHandle resource)
         {
             XY_ASSERT(resource < m_resources.size(), "Invalid resource handle");
-            return *stdx::any_cast<T>(&m_resources[resource]);
+            return *std::any_cast<T>(&m_resources[resource]);
         }
         
         /*!
@@ -141,7 +120,7 @@ namespace xy
         
     private:
         // Container of the resources
-        std::vector<stdx::any> m_resources;
+        std::vector<std::any> m_resources;
         
         // Resource loaders mapped by their type index
         std::unordered_map<std::type_index, ResourceLoader> m_loaders;

--- a/xyginext/include/xyginext/resources/ResourceHandler.hpp
+++ b/xyginext/include/xyginext/resources/ResourceHandler.hpp
@@ -138,7 +138,11 @@ namespace xy
             m_resources.emplace_back(m_loaders[ti].loader(path));
             
             // If it wasn't loaded, use fallback
+            #ifdef __APPLE__
             if (m_resources.back().empty())
+            #else
+            if (m_resources.back().has_value())
+            #endif
             {
                 m_resources.back() = m_loaders[ti].fallback();
             }

--- a/xyginext/include/xyginext/resources/ResourceHandler.hpp
+++ b/xyginext/include/xyginext/resources/ResourceHandler.hpp
@@ -102,12 +102,12 @@ namespace xy
             #ifdef __APPLE__
             if (m_resources.back().empty())
             #else
-            if (m_resources.back().has_value())
+            if (!m_resources.back().has_value())
             #endif
             {
                 m_resources.back() = m_loaders[ti].fallback();
             }
-            return static_cast<std::uint16_t>(m_resources.size()-1);
+            return m_resources.size()-1;
         }
         
         /*!

--- a/xyginext/include/xyginext/resources/ResourceHandler.hpp
+++ b/xyginext/include/xyginext/resources/ResourceHandler.hpp
@@ -1,0 +1,179 @@
+/*********************************************************************
+(c) Matt Marchant 2017 - 2018
+http://trederia.blogspot.com
+
+xygineXT - Zlib license.
+
+This software is provided 'as-is', without any express or
+implied warranty. In no event will the authors be held
+liable for any damages arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute
+it freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented;
+you must not claim that you wrote the original software.
+If you use this software in a product, an acknowledgment
+in the product documentation would be appreciated but
+is not required.
+
+2. Altered source versions must be plainly marked as such,
+and must not be misrepresented as being the original software.
+
+3. This notice may not be removed or altered from any
+source distribution.
+*********************************************************************/
+
+#pragma once
+
+#include "xyginext/core/Log.hpp"
+#include "xyginext/core/Assert.hpp"
+#include "xyginext/resources/DejaVuSans.hpp"
+
+#include <SFML/Graphics/Texture.hpp>
+#include <SFML/Graphics/Font.hpp>
+
+#include <unordered_map>
+#include <vector>
+#include <typeindex>
+
+// Fiddling for experimental features
+#if __has_include(<any>)
+
+#include <any>
+namespace stdx {
+    using namespace ::std;
+}
+#elif __has_include(<experimental/any>)
+#include <experimental/any>
+namespace stdx {
+    using namespace ::std;
+    using namespace ::std::experimental;
+}
+
+#else
+#error <experimental/optional> and <optional> not found
+#endif
+
+namespace xy
+{
+    /*!
+     \brief Handle for a Resource
+     
+     Basically just an index to the resource in the vector
+     */
+    using ResourceHandle = std::uint16_t;
+    
+    /*!
+     \brief Struct responsible for loading resources
+     
+     Contains a method to load from a path, and a fallback if the resource isn't found
+     */
+    struct ResourceLoader
+    {
+        std::function<stdx::any(const std::string&)>   loader;
+        std::function<stdx::any()>                     fallback;
+    };
+    
+    /*!
+     \brief Class for generic resource management using handles
+     
+     The user must explicitly load resources, and store the returned handle.
+     Then they can use the handle to retreive the resource when required
+     
+     */
+    class XY_EXPORT_API ResourceHandler
+    {
+    public:
+        
+        // Constructor
+        ResourceHandler()
+        {
+            // Add a texture loader
+            ResourceLoader texLoader;
+            texLoader.loader = [](const std::string& path)
+            {
+                sf::Texture tex;
+                return tex.loadFromFile(path) ? tex : stdx::any();
+            };
+            
+            texLoader.fallback = []()
+            {
+                return sf::Texture();
+            };
+            
+            // And a font loader
+            ResourceLoader fontLoader;
+            fontLoader.loader = [](const std::string& path)
+            {
+                sf::Font font;
+                return font.loadFromFile(path) ? font : stdx::any();
+            };
+            
+            fontLoader.fallback = []()
+            {
+                sf::Font font;
+                font.loadFromMemory(DejaVuSans_ttf.data(), DejaVuSans_Size);
+                return font;
+            };
+            
+            getLoader<sf::Texture>() = texLoader;
+            getLoader<sf::Font>() = fontLoader;
+        }
+        
+        /*!
+         \brief Load a resource
+         
+         Load a resource from a path, returns a handle to the resource
+         */
+        template<class T>
+        ResourceHandle load(const std::string& path)
+        {
+            // Find the correct loader for the type
+            std::type_index ti = typeid(T);
+            
+            XY_ASSERT(m_loaders.count(ti), std::string("Resource loader not found for ") + std::string(ti.name()));
+            
+            m_resources.emplace_back(m_loaders[ti].loader(path));
+            
+            // If it wasn't loaded, use fallback
+            if (m_resources.back().empty())
+            {
+                m_resources.back() = m_loaders[ti].fallback();
+            }
+            return static_cast<std::uint16_t>(m_resources.size()-1);
+        }
+        
+        /*!
+         \brief Get a resource
+         
+         Get a resource from it's handle
+         */
+        template<class T>
+        T& get(const ResourceHandle& resource)
+        {
+            XY_ASSERT(resource < m_resources.size(), "Invalid resource handle");
+            return *stdx::any_cast<T>(&m_resources[resource]);
+        }
+        
+        /*!
+         \brief Get the loader for a resource type
+         
+         Could be getter & setter if preferred? I find this more convenient when
+         you just want to modify the fallback or something...
+         */
+        template<class T>
+        ResourceLoader& getLoader()
+        {
+            return m_loaders[typeid(T)];
+        }
+        
+    private:
+        // Container of the resources
+        std::vector<stdx::any> m_resources;
+        
+        // Resource loaders mapped by their type index
+        std::unordered_map<std::type_index, ResourceLoader> m_loaders;
+    };
+}

--- a/xyginext/include/xyginext/resources/ResourceHandler.hpp
+++ b/xyginext/include/xyginext/resources/ResourceHandler.hpp
@@ -124,9 +124,6 @@ namespace xy
         
         /*!
          \brief Get the loader for a resource type
-         
-         Could be getter & setter if preferred? I find this more convenient when
-         you just want to modify the fallback or something...
          */
         template<class T>
         ResourceLoader& getLoader()

--- a/xyginext/include/xyginext/resources/ResourceHandler.hpp
+++ b/xyginext/include/xyginext/resources/ResourceHandler.hpp
@@ -53,7 +53,7 @@ namespace stdx {
 }
 
 #else
-#error <experimental/optional> and <optional> not found
+#error <experimental/any> and <any> not found
 #endif
 
 namespace xy

--- a/xyginext/src/CMakeLists.txt
+++ b/xyginext/src/CMakeLists.txt
@@ -76,6 +76,7 @@ set(PROJECT_SRC ${PROJECT_SRC}
   ${CMAKE_CURRENT_SOURCE_DIR}/network/NetHost.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/network/NetPeer.cpp
 
+  ${CMAKE_CURRENT_SOURCE_DIR}/resources/DejaVuSans.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/resources/FontResource.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/resources/ShaderResource.cpp
   

--- a/xyginext/src/CMakeLists.txt
+++ b/xyginext/src/CMakeLists.txt
@@ -78,6 +78,7 @@ set(PROJECT_SRC ${PROJECT_SRC}
 
   ${CMAKE_CURRENT_SOURCE_DIR}/resources/DejaVuSans.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/resources/FontResource.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/resources/ResourceHandler.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/resources/ShaderResource.cpp
   
   ${CMAKE_CURRENT_SOURCE_DIR}/util/Random.cpp

--- a/xyginext/src/audio/AudioScape.cpp
+++ b/xyginext/src/audio/AudioScape.cpp
@@ -110,11 +110,11 @@ AudioEmitter AudioScape::getEmitter(const std::string& name) const
 
         if (streaming)
         {
-            emitter.setSource(xy::FileSystem::getResourcePath() + path);
+            emitter.setSource(path);
         }
         else
         {
-            emitter.setSource(m_audioResource.get(xy::FileSystem::getResourcePath() + path));
+            emitter.setSource(m_audioResource.get(path));
         }
 
         const auto& properties = cfg->second.getProperties();

--- a/xyginext/src/ecs/components/ParticleEmitter.cpp
+++ b/xyginext/src/ecs/components/ParticleEmitter.cpp
@@ -27,6 +27,7 @@ source distribution.
 
 #include "xyginext/ecs/components/ParticleEmitter.hpp"
 #include "xyginext/resources/Resource.hpp"
+#include "xyginext/resources/ResourceHandler.hpp"
 #include "xyginext/core/ConfigFile.hpp"
 
 using namespace xy;
@@ -181,3 +182,129 @@ bool EmitterSettings::loadFromFile(const std::string& path, TextureResource& tex
 
     return false;
 }
+
+bool EmitterSettings::loadFromFile(const std::string& path, ResourceHandler& textureResource)
+{
+    ConfigFile cfg;
+    if (!cfg.loadFromFile(xy::FileSystem::getResourcePath() + path)) return false;
+    
+    if (cfg.getName() == "particle_system")
+    {
+        const auto& properties = cfg.getProperties();
+        for (const auto& p : properties)
+        {
+            auto name = p.getName();
+            if (name == "src")
+            {
+                auto handle = textureResource.load<sf::Texture>(p.getValue<std::string>());
+                texture = &textureResource.get<sf::Texture>(handle);
+            }
+            else if (name == "blendmode")
+            {
+                auto mode = p.getValue<std::string>();
+                if (mode == "add")
+                {
+                    blendmode = sf::BlendAdd;
+                }
+                else if (mode == "multiply")
+                {
+                    blendmode = sf::BlendMultiply;
+                }
+                else
+                {
+                    blendmode = sf::BlendAlpha;
+                }
+            }
+            else if (name == "gravity")
+            {
+                gravity = p.getValue<sf::Vector2f>();
+            }
+            else if (name == "velocity")
+            {
+                initialVelocity = p.getValue<sf::Vector2f>();
+            }
+            else if (name == "spread")
+            {
+                spread = p.getValue<float>() / 2.f; //because the initial rotation is +- this
+            }
+            else if (name == "lifetime")
+            {
+                lifetime = p.getValue<float>();
+            }
+            else if (name == "lifetime_variance")
+            {
+                lifetimeVariance = p.getValue<float>();
+            }
+            else if (name == "colour")
+            {
+                colour = p.getValue<sf::Color>();
+            }
+            else if (name == "random_initial_rotation")
+            {
+                randomInitialRotation = p.getValue<bool>();
+            }
+            else if (name == "rotation_speed")
+            {
+                rotationSpeed = p.getValue<float>();
+            }
+            else if (name == "scale_affector")
+            {
+                scaleModifier = p.getValue<float>();
+            }
+            else if (name == "size")
+            {
+                size = p.getValue<float>();
+            }
+            else if (name == "emit_rate")
+            {
+                emitRate = p.getValue<float>();
+            }
+            else if (name == "emit_count")
+            {
+                emitCount = p.getValue<sf::Int32>();
+            }
+            else if (name == "spawn_radius")
+            {
+                spawnRadius = p.getValue<float>();
+            }
+            else if (name == "spawn_offset")
+            {
+                spawnOffset = p.getValue<sf::Vector2f>();
+            }
+            else if (name == "release_count")
+            {
+                releaseCount = p.getValue<sf::Int32>();
+            }
+        }
+        
+        const auto& objects = cfg.getObjects();
+        for (const auto& o : objects)
+        {
+            //load force array
+            if (o.getName() == "forces")
+            {
+                const auto& props = o.getProperties();
+                std::size_t currentForce = 0;
+                for (const auto& force : props)
+                {
+                    if (force.getName() == "force")
+                    {
+                        forces[currentForce++] = force.getValue<sf::Vector2f>();
+                        if (currentForce == forces.size())
+                        {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        
+        if (!texture)
+        {
+            Logger::log(path + ": no texture property found", Logger::Type::Warning);
+        }
+    }
+    
+    return false;
+}
+

--- a/xyginext/src/ecs/components/Sprite.cpp
+++ b/xyginext/src/ecs/components/Sprite.cpp
@@ -49,6 +49,15 @@ Sprite::Sprite(const sf::Texture& texture)
     setTexture(texture);
 }
 
+/*Sprite::Sprite(const ResourceHandle& texture)
+: m_texture     (nullptr),
+m_colour        (sf::Color::White),
+m_dirty         (true),
+m_animationCount(0)
+{
+    setTexture(texture);
+}*/
+
 //public
 void Sprite::setTexture(const sf::Texture& texture)
 {
@@ -56,6 +65,14 @@ void Sprite::setTexture(const sf::Texture& texture)
     auto size = static_cast<sf::Vector2f>(texture.getSize());
     setTextureRect({ sf::Vector2f(), size });
 }
+
+/*
+void Sprite::setTexture(const ResourceHandle& texture)
+{
+    // hrm...
+    m_textureHandle = texture;
+}
+ */
 
 void Sprite::setTextureRect(sf::FloatRect rect)
 {

--- a/xyginext/src/graphics/SpriteSheet.cpp
+++ b/xyginext/src/graphics/SpriteSheet.cpp
@@ -28,6 +28,7 @@ source distribution.
 #include "xyginext/core/ConfigFile.hpp"
 #include "xyginext/graphics/SpriteSheet.hpp"
 #include "xyginext/resources/Resource.hpp"
+#include "xyginext/resources/ResourceHandler.hpp"
 
 using namespace xy;
 
@@ -175,6 +176,131 @@ bool SpriteSheet::loadFromFile(const std::string& path, TextureResource& texture
         }
     }
 
+    //LOG("Found " + std::to_string(count) + " sprites in " + path, Logger::Type::Info);
+    return count > 0;
+}
+
+bool SpriteSheet::loadFromFile(const std::string& path, ResourceHandler& textures)
+{
+    ConfigFile sheetFile;
+    if (!sheetFile.loadFromFile(xy::FileSystem::getResourcePath() + path))
+    {
+        return false;
+    }
+    
+    m_sprites.clear();
+    m_animations.clear();
+    
+    std::size_t count = 0;
+    
+    sf::Texture* texture = nullptr;
+    sf::BlendMode blendMode = sf::BlendAlpha;
+    
+    //validate sprites, increase count
+    if (auto* p = sheetFile.findProperty("src"))
+    {
+        m_texturePath = p->getValue<std::string>();
+        auto handle = textures.load<sf::Texture>(m_texturePath);
+        texture = &textures.get<sf::Texture>(handle);
+    }
+    else
+    {
+        LOG(sheetFile.getId() + " missing texture property", Logger::Type::Error);
+        return false;
+    }
+    
+    if (auto* p = sheetFile.findProperty("blendmode"))
+    {
+        std::string mode = p->getValue<std::string>();
+        if (mode == "add") blendMode = sf::BlendAdd;
+        else if (mode == "multiply") blendMode = sf::BlendMultiply;
+        else if (mode == "none") blendMode = sf::BlendNone;
+    }
+    
+    if (auto* p = sheetFile.findProperty("smooth"))
+    {
+        texture->setSmooth(p->getValue<bool>());
+    }
+    
+    const auto& sheetObjs = sheetFile.getObjects();
+    for (const auto& spr : sheetObjs)
+    {
+        if (spr.getName() == "sprite")
+        {
+            std::string spriteName = spr.getId();
+            if (m_sprites.count(spriteName) > 0)
+            {
+                Logger::log(spriteName + " already exists in sprite sheet", Logger::Type::Error);
+                continue;
+            }
+            
+            Sprite spriteComponent;
+            if (texture != nullptr)
+            {
+                spriteComponent.setTexture(*texture);
+            }
+            
+            //if (auto* p = spr.findProperty("blendmode"))
+            //{
+            //    //override sheet mode
+            //    std::string mode = p->getValue<std::string>();
+            //    if (mode == "add") spriteComponent.setBlendMode(sf::BlendAdd);
+            //    else if (mode == "multiply") spriteComponent.setBlendMode(sf::BlendMultiply);
+            //    else if (mode == "none") spriteComponent.setBlendMode(sf::BlendNone);
+            //}
+            //else
+            //{
+            //    spriteComponent.setBlendMode(blendMode);
+            //}
+            
+            if (auto* p = spr.findProperty("bounds"))
+            {
+                spriteComponent.setTextureRect(p->getValue<sf::FloatRect>());
+            }
+            
+            if (auto* p = spr.findProperty("colour"))
+            {
+                spriteComponent.setColour(p->getValue<sf::Color>());
+            }
+            
+            const auto& spriteObjs = spr.getObjects();
+            for (const auto& sprOb : spriteObjs)
+            {
+                if (sprOb.getName() == "animation")
+                {
+                    auto& anim = spriteComponent.m_animations[spriteComponent.m_animationCount];
+                    
+                    const auto& properties = sprOb.getProperties();
+                    for (const auto& p : properties)
+                    {
+                        std::string name = p.getName();
+                        if (name == "frame")
+                        {
+                            anim.frames[anim.frameCount++] = p.getValue<sf::FloatRect>();
+                        }
+                        else if (name == "framerate")
+                        {
+                            anim.framerate = p.getValue<float>();
+                        }
+                        else if (name == "loop")
+                        {
+                            anim.looped = p.getValue<bool>();
+                        }
+                    }
+                    
+                    auto animId = sprOb.getId();
+                    m_animations[spriteName].push_back(animId);
+                    animId.copy(anim.id.data(), animId.length());
+                    
+                    spriteComponent.m_animationCount++;
+                }
+            }
+            
+            m_sprites.insert(std::make_pair(spriteName, spriteComponent));
+            count++;
+        }
+    }
+    
     //LOG("Found " + std::to_string(count) + " sprites in " + path, Logger::Type::Info);
     return count > 0;
 }

--- a/xyginext/src/resources/ResourceHandler.cpp
+++ b/xyginext/src/resources/ResourceHandler.cpp
@@ -1,4 +1,8 @@
+#include <SFML/Graphics/Texture.hpp>
+#include <SFML/Graphics/Font.hpp>
+
 #include "xyginext/resources/ResourceHandler.hpp"
+#include "xyginext/resources/DejaVuSans.hpp"
 
 using namespace xy;
 ResourceHandler::ResourceHandler()
@@ -8,7 +12,7 @@ ResourceHandler::ResourceHandler()
     texLoader.loader = [](const std::string& path)
     {
         sf::Texture tex;
-        return tex.loadFromFile(path) ? tex : stdx::any();
+        return tex.loadFromFile(xy::FileSystem::getResourcePath() + path) ? tex : stdx::any();
     };
 
     texLoader.fallback = []()
@@ -21,7 +25,7 @@ ResourceHandler::ResourceHandler()
     fontLoader.loader = [](const std::string& path)
     {
         sf::Font font;
-        return font.loadFromFile(path) ? font : stdx::any();
+        return font.loadFromFile(xy::FileSystem::getResourcePath() + path) ? font : stdx::any();
     };
 
     fontLoader.fallback = []()

--- a/xyginext/src/resources/ResourceHandler.cpp
+++ b/xyginext/src/resources/ResourceHandler.cpp
@@ -11,8 +11,12 @@ ResourceHandler::ResourceHandler()
     ResourceLoader texLoader;
     texLoader.loader = [](const std::string& path)
     {
-        sf::Texture tex;
-        return tex.loadFromFile(xy::FileSystem::getResourcePath() + path) ? tex : stdx::any();
+        //a bit convoluted but prevents a copy operation
+        //which can throw occasional opengl errors
+        auto tex = std::make_any<sf::Texture>();
+        auto& tr = *std::any_cast<sf::Texture>(&tex);
+        tr.loadFromFile(xy::FileSystem::getResourcePath() + path);
+        return tex;
     };
 
     texLoader.fallback = []()

--- a/xyginext/src/resources/ResourceHandler.cpp
+++ b/xyginext/src/resources/ResourceHandler.cpp
@@ -29,7 +29,7 @@ ResourceHandler::ResourceHandler()
     fontLoader.loader = [](const std::string& path)
     {
         sf::Font font;
-        return font.loadFromFile(xy::FileSystem::getResourcePath() + path) ? font : stdx::any();
+        return font.loadFromFile(xy::FileSystem::getResourcePath() + path) ? font : std::any();
     };
 
     fontLoader.fallback = []()

--- a/xyginext/src/resources/ResourceHandler.cpp
+++ b/xyginext/src/resources/ResourceHandler.cpp
@@ -1,0 +1,36 @@
+#include "xyginext/resources/ResourceHandler.hpp"
+
+using namespace xy;
+ResourceHandler::ResourceHandler()
+{
+    // Add a texture loader
+    ResourceLoader texLoader;
+    texLoader.loader = [](const std::string& path)
+    {
+        sf::Texture tex;
+        return tex.loadFromFile(path) ? tex : stdx::any();
+    };
+
+    texLoader.fallback = []()
+    {
+        return sf::Texture();
+    };
+
+    // And a font loader
+    ResourceLoader fontLoader;
+    fontLoader.loader = [](const std::string& path)
+    {
+        sf::Font font;
+        return font.loadFromFile(path) ? font : stdx::any();
+    };
+
+    fontLoader.fallback = []()
+    {
+        sf::Font font;
+        font.loadFromMemory(DejaVuSans_ttf.data(), DejaVuSans_ttf.size());
+        return font;
+    };
+
+    getLoader<sf::Texture>() = texLoader;
+    getLoader<sf::Font>() = fontLoader;
+}

--- a/xyginext/xyginext.vcxproj
+++ b/xyginext/xyginext.vcxproj
@@ -88,6 +88,7 @@
       <AdditionalIncludeDirectories>$(SolutionDir)extlibs\include;$(ProjectDir)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_ITERATOR_DEBUG_LEVEL=0;XY_DEBUG;_CRT_SECURE_NO_WARNINGS;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(SolutionDir)extlibs\bin\msvc_x64\sfml\Debug;%(AdditionalLibraryDirectories);$(SolutionDir)extlibs\bin\msvc_x64\enet</AdditionalLibraryDirectories>
@@ -117,6 +118,7 @@
       <AdditionalIncludeDirectories>$(SolutionDir)extlibs\include;$(ProjectDir)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -194,7 +196,9 @@
     <ClCompile Include="src\network\NetEvent.cpp" />
     <ClCompile Include="src\network\NetHost.cpp" />
     <ClCompile Include="src\network\NetPeer.cpp" />
+    <ClCompile Include="src\resources\DejaVuSans.cpp" />
     <ClCompile Include="src\resources\FontResource.cpp" />
+    <ClCompile Include="src\resources\ResourceHandler.cpp" />
     <ClCompile Include="src\resources\ShaderResource.cpp" />
     <ClCompile Include="src\util\Random.cpp" />
   </ItemGroup>
@@ -267,7 +271,9 @@
     <ClInclude Include="include\xyginext\network\NetData.hpp" />
     <ClInclude Include="include\xyginext\network\NetHost.hpp" />
     <ClInclude Include="include\xyginext\network\NetImpl.hpp" />
+    <ClInclude Include="include\xyginext\resources\DejaVuSans.hpp" />
     <ClInclude Include="include\xyginext\resources\Resource.hpp" />
+    <ClInclude Include="include\xyginext\resources\ResourceHandler.hpp" />
     <ClInclude Include="include\xyginext\resources\ShaderResource.hpp" />
     <ClInclude Include="include\xyginext\util\Const.hpp" />
     <ClInclude Include="include\xyginext\util\Math.hpp" />

--- a/xyginext/xyginext.vcxproj.filters
+++ b/xyginext/xyginext.vcxproj.filters
@@ -306,6 +306,12 @@
     <ClCompile Include="src\ecs\systems\DynamicTreeSystem.cpp">
       <Filter>Source Files\ecs\systems</Filter>
     </ClCompile>
+    <ClCompile Include="src\resources\DejaVuSans.cpp">
+      <Filter>Source Files\resources</Filter>
+    </ClCompile>
+    <ClCompile Include="src\resources\ResourceHandler.cpp">
+      <Filter>Source Files\resources</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\xyginext\Config.hpp">
@@ -536,6 +542,7 @@
     <ClInclude Include="include\xyginext\network\EnetHostImpl.hpp">
       <Filter>Header Files\network</Filter>
     </ClInclude>
+<<<<<<< HEAD
     <ClInclude Include="include\xyginext\ecs\systems\TextSystem.hpp">
       <Filter>Header Files\ecs\systems</Filter>
     </ClInclude>
@@ -547,6 +554,13 @@
     </ClInclude>
     <ClInclude Include="include\xyginext\ecs\systems\DynamicTreeSystem.hpp">
       <Filter>Header Files\ecs\systems</Filter>
+=======
+    <ClInclude Include="include\xyginext\resources\DejaVuSans.hpp">
+      <Filter>Header Files\resources</Filter>
+    </ClInclude>
+    <ClInclude Include="include\xyginext\resources\ResourceHandler.hpp">
+      <Filter>Header Files\resources</Filter>
+>>>>>>> moved resource holder constructor to own file
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/xyginext/xyginext.vcxproj.filters
+++ b/xyginext/xyginext.vcxproj.filters
@@ -306,10 +306,10 @@
     <ClCompile Include="src\ecs\systems\DynamicTreeSystem.cpp">
       <Filter>Source Files\ecs\systems</Filter>
     </ClCompile>
-    <ClCompile Include="src\resources\DejaVuSans.cpp">
+    <ClCompile Include="src\resources\ResourceHandler.cpp">
       <Filter>Source Files\resources</Filter>
     </ClCompile>
-    <ClCompile Include="src\resources\ResourceHandler.cpp">
+    <ClCompile Include="src\resources\DejaVuSans.cpp">
       <Filter>Source Files\resources</Filter>
     </ClCompile>
   </ItemGroup>
@@ -542,7 +542,6 @@
     <ClInclude Include="include\xyginext\network\EnetHostImpl.hpp">
       <Filter>Header Files\network</Filter>
     </ClInclude>
-<<<<<<< HEAD
     <ClInclude Include="include\xyginext\ecs\systems\TextSystem.hpp">
       <Filter>Header Files\ecs\systems</Filter>
     </ClInclude>
@@ -554,13 +553,12 @@
     </ClInclude>
     <ClInclude Include="include\xyginext\ecs\systems\DynamicTreeSystem.hpp">
       <Filter>Header Files\ecs\systems</Filter>
-=======
-    <ClInclude Include="include\xyginext\resources\DejaVuSans.hpp">
-      <Filter>Header Files\resources</Filter>
     </ClInclude>
     <ClInclude Include="include\xyginext\resources\ResourceHandler.hpp">
       <Filter>Header Files\resources</Filter>
->>>>>>> moved resource holder constructor to own file
+    </ClInclude>
+    <ClInclude Include="include\xyginext\resources\DejaVuSans.hpp">
+      <Filter>Header Files\resources</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
A first draft of an alternative to the current resource management. The drive behind this was to firstly create a system based around handles to make serialising components (and therefore serialising scenes) possible, and secondly to have one system to manage all types of resources

You must explicitly load the resource with `load<type>(path)` which returns a handle. You can then use that handle to access the resource with `get<type>(handle)`.

There is also functionality fo the user to add their own type of resource, by adding a `ResourceLoader`. For an example see the constructor of `ResourceHandler` where I've added the default loaders for `sf::Texture` and `sf::Font`.

This doesn't have any effect on the existing resource management, as you can see I've left the Demo mostly as is, just modifying the Menu State to use this method of resource handling as an example.

This does make use of std::any, so c++17 is required. ~~I haven't made this change in the CMakeLists, but I've added some macros which should emit a compiler error if someone tries to use `ResourceHandler` without c++17 enabled.~~ This didn't work as intended, so c++17 is an hard requirement unless I can work some way around it - Something to think about...

Only a first draft, so completely open to feedback/changes