### PR TITLE
Generate Text local bounds if not already generated

### DIFF
--- a/xyginext/src/ecs/systems/TextRenderer.cpp
+++ b/xyginext/src/ecs/systems/TextRenderer.cpp
@@ -99,7 +99,7 @@ void TextRenderer::process(float)
             float x = 0.f;
             float y = static_cast<float>(text.m_charSize);
 
-            float minX = y;
+            float minX = x;
             float minY = y;
             float maxX = 0.f;
             float maxY = 0.f;


### PR DESCRIPTION
Means you can query text bounds immediately without waiting for the scene to update.

Ideally I'd prefer not to just duplicate what text renderer does, but I couldn't work out a tidy way of avoiding it, so this was the path of least resistance! 

Also fixed what I presume was a typo in TextRenderer? let me know if I'm misunderstanding that