### PR TITLE
CMake - download dependencies if not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.11)
 
 # Rename this variable to change the project name
 set(PROJECT_NAME xyginext)
@@ -47,12 +47,46 @@ endif()
 
 # Only works with SFML version 2.5 and above
 SET(SFML_MIN_VERSION 2.5)
-find_package(SFML REQUIRED COMPONENTS graphics window audio system)
+find_package(SFML QUIET COMPONENTS graphics window audio system)
+
+# If SFML is not found, get it from github
+if (NOT SFML_FOUND)
+  message(STATUS "SFML not found, fetching from github...")
+  include(FetchContent)
+  FetchContent_Declare(
+    sfml
+    GIT_REPOSITORY https://github.com/sfml/sfml.git
+    # 2.5.1 actually uses auto_ptr(!) which is incompatible with 
+    # modern c++ so we use a slightly later commit which fixes
+    # this issue
+    GIT_TAG        bf92efe9a4035fee0258386173d53556aa196e49
+  )
+  FetchContent_MakeAvailable(sfml)
+endif()
 
 # Also require OpenGL and ENet
 SET (OpenGL_GL_PREFERENCE "GLVND")
 find_package(OpenGL REQUIRED)
-find_package(ENet REQUIRED)
+find_package(ENet QUIET)
+
+# If ENet isn't found we can get it from github
+if (NOT ENet_FOUND)
+  message(STATUS "ENet not found, fetching from github...")
+  include(FetchContent)
+  FetchContent_Declare(
+    enet
+    GIT_REPOSITORY https://github.com/lsalzman/enet.git
+    GIT_TAG        v1.3.16
+  )
+  FetchContent_MakeAvailable(enet)
+
+  # ENet's cmake is unbelievably basic, so we have to set some stuff ourselves
+  set(ENET_INCLUDE_DIR "${enet_SOURCE_DIR}/include")
+  set(ENET_LIBRARIES $<TARGET_FILE:enet>)
+  if (WIN32)
+    list(APPEND ENET_LIBRARIES ws2_32 winmm)
+  endif()
+endif()
 
 # xyginext source files
 add_subdirectory(xyginext/src)
@@ -146,7 +180,21 @@ if (BUILD_DEMO)
   endif()
   add_dependencies(${DEMO_NAME} ${PROJECT_NAME})
 
-  find_package(TMXLITE REQUIRED)
+  find_package(TMXLITE QUIET)
+
+  if (NOT ${TMXLITE_FOUND})
+    message(STATUS "tmxlite not found, fetching from github...")
+    include(FetchContent)
+    FetchContent_Declare(
+      tmxlite
+      GIT_REPOSITORY https://github.com/fallahn/tmxlite
+      GIT_TAG        v1.2.1
+    )
+    FetchContent_MakeAvailable(tmxlite)
+    add_subdirectory(${tmxlite_SOURCE_DIR}/tmxlite)
+    set(TMXLITE_LIBRARIES $<TARGET_LINKER_FILE:tmxlite>)
+    set(TMXLITE_INCLUDE_DIR ${tmxlite_SOURCE_DIR}/tmxlite/include)
+  endif()
 
   if(UNIX AND NOT APPLE)
     find_package(X11 REQUIRED)


### PR DESCRIPTION
Uses CMake's [FetchContent](https://cmake.org/cmake/help/v3.11/module/FetchContent.html) module to download SFML, enet and/or tmxlite if they are not found.

Means a bump to cmake version 3.11, which came out 2.5 years ago

🏴‍☠️ 